### PR TITLE
Updated main error page.

### DIFF
--- a/concepts/errors.md
+++ b/concepts/errors.md
@@ -36,7 +36,7 @@ The following table lists and describes the HTTP status codes that can be return
 | 500         | Internal Server Error           | There was an internal server error while processing the request.                                                                       |
 | 501         | Not Implemented                 | The requested feature isn’t implemented.                                                                                               |
 | 503         | Service Unavailable             | The service is temporarily unavailable for maintenance or is overloaded. You may repeat the request after a delay, the length of which may be specified in a Retry-After header.|
-| 504         | Gateway Timeout                 | The server, while acting as a proxy, did not receive a timely response from the upstream server it needed to access in attempting to complete the request. May occur together with 503. |
+| 504         | Gateway Timeout                 | The server, while acting as a proxy, did not receive a timely response from the upstream server it needed to access in attempting to complete the request. |
 | 507         | Insufficient Storage            | The maximum storage quota has been reached.                                                                                            |
 | 509         | Bandwidth Limit Exceeded        | Your app has been throttled for exceeding the maximum bandwidth cap. Your app can retry the request again after more time has elapsed. |
 
@@ -49,9 +49,10 @@ named **error**. This object includes all the details of the error. You can use 
 ```json
 {
   "error": {
-    "code": "invalidRange",
+    "code": "badRequest",
     "message": "Uploaded fragment overlaps with existing data.",
     "innerError": {
+      "code": "invalidRange",
       "request-id": "request-id",
       "date": "date-time"
     }
@@ -65,32 +66,24 @@ named **error**. This object includes all the details of the error. You can use 
 
 The error resource is returned whenever an error occurs in the processing of a request.
 
-Error responses follow the definition in the
-[OData v4](https://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091)
-specification for error responses.
+Error responses follow the definition in the 
+[Microsoft REST API Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses).
 
 ### JSON representation
 
-The error resource is composed of these resources:
+The error resource is composed of a single resource:
 
-<!-- { "blockType": "resource", "@odata.type": "odata.error" } -->
+<!-- { "blockType": "resource" } -->
 ```json
 {
-  "error": { "@odata.type": "odata.error" }
-}
-```
-
-#### odata.error resource type
-
-Inside the error response is an error resource that includes the following
-properties:
-
-<!-- { "blockType": "resource", "@odata.type": "odata.error", "optionalProperties": [ "target", "details", "innererror"] } -->
-```json
-{
-  "code": "string",
-  "message": "string",
-  "innererror": { "@odata.type": "odata.error" }
+  "error": {
+    "code": "string",
+    "message": "string",
+    "innererror": { 
+      "code": "string"
+    }
+    "details": []
+  }
 }
 ```
 
@@ -98,122 +91,31 @@ properties:
 |:---------------|:-----------------------|:-----------------------------------------------------------------------------------------------------------|
 | **code**       | string                 | An error code string for the error that occurred                                                            |
 | **message**    | string                 | A developer ready message about the error that occurred. This should not be displayed to the user directly. |
-| **innererror** | error object           | Optional. Additional error objects that may be more specific than the top level error.                     |
+| **innererror** | error object           | Optional. An additional error object that may be more specific than the top level error.                     |
+| **details**    | error object           | Optional. A list of additional error objects that may provide a breakdown of multiple errors encountered whilst processing the request. |
 
-<!--<a name="msg_code_property"> </a> -->
+<!--<a name="msg_properties"> </a> -->
 
-#### Code property
+#### Properties
 
-The `code` property contains one of the following possible values. Your apps should be
-prepared to handle any one of these errors.
-
-| Code                      | Description
-|:--------------------------|:--------------
-| **accessDenied**          | The caller doesn't have permission to perform the action.
-| **activityLimitReached**  | The app or user has been throttled.
-| **extensionError**        | The mailbox is located on premises and the Exchange server does not support federated Microsoft Graph requests, or an [application policy](./auth-limit-mailbox-access.md) prevents the application from accessing the mailbox.
-| **generalException**      | An unspecified error has occurred.
-| **invalidRange**          | The specified byte range is invalid or unavailable.
-| **invalidRequest**        | The request is malformed or incorrect.
-| **itemNotFound**          | The resource could not be found.
-| **malwareDetected**       | Malware was detected in the requested resource.
-| **nameAlreadyExists**     | The specified item name already exists.
-| **notAllowed**            | The action is not allowed by the system.
-| **notSupported**          | The request is not supported by the system.
-| **resourceModified**      | The resource being updated has changed since the caller last read it, usually an eTag mismatch.
-| **resyncRequired**        | The delta token is no longer valid, and the app must reset the sync state.
-| **serviceNotAvailable**   | The service is not available. Try the request again after a delay. There may be a Retry-After header.
-| **syncStateNotFound**     | The sync state generation is not found. The delta token is expired and data must be synchronized again.
-| **quotaLimitReached**     | The user has reached their quota limit.
-| **unauthenticated**       | The caller is not authenticated.
+The `code` property contains a machine-readable value that you can take a dependency on in your code.  
 
 The `innererror` object might recursively contain more `innererror` objects
-with additional, more specific error codes. When handling an error, apps
-should loop through all the error codes available and use the most detailed
-one that they understand. Some of the more detailed codes are listed at the
-bottom of this page.
+with additional, more specific error `codes` properties. When handling an error, apps
+should loop through all the nested error codes available and use the most detailed
+one that they understand.
 
-To verify that an error object is an error you are expecting, you must loop
-over the `innererror` objects, looking for the error codes you expect. For example:
-
-```csharp
-public bool IsError(string expectedErrorCode)
-{
-    OneDriveInnerError errorCode = this.Error;
-    while (null != errorCode)
-    {
-        if (errorCode.Code == expectedErrorCode)
-            return true;
-        errorCode = errorCode.InnerError;
-    }
-    return false;
-}
-```
-
-For an example that shows how to properly handle errors, see
-[Error Code Handling](https://gist.github.com/rgregg/a1866be15e685983b441).
+The 'message' property is a human-readable value describing the error condition.  You should not take any dependency on the content of this value in your code. 
 
 The `message` property at the root contains an error message intended for the
 developer to read. Error messages are not localized and shouldn't be displayed
-directly to the user. When handling errors, your code should not branch based on
-`message` values because they can change at any time, and they often contain
+directly to the user. When handling errors, your code should not take any dependency on the 
+content of `message` values because they can change at any time, and they often contain
 dynamic information specific to the failed request. You should only code
 against error codes returned in `code` properties.
 
-#### Detailed error codes
-
-The following are some additional errors that your app might encounter within the nested
-`innererror` objects. Apps are not required to handle these, but can if they
-choose. The service might add new error codes or stop returning old ones at any
-time, so it is important that all apps be able to handle the [basic error codes](#code-property).
-
-| Code                               | Description
-|:-----------------------------------|:----------------------------------------------------------
-| **accessRestricted**               | Access restricted to the item's owner.
-| **cannotSnapshotTree**             | Failed to get a consistent delta snapshot. Try again later.
-| **childItemCountExceeded**         | Max limit on the number of child items was reached.
-| **entityTagDoesNotMatch**          | ETag does not match the current item's value.
-| **fragmentLengthMismatch**         | Declared total size for this fragment is different from that of the upload session.
-| **fragmentOutOfOrder**             | Uploaded fragment is out of order.
-| **fragmentOverlap**                | Uploaded fragment overlaps with existing data.
-| **invalidAcceptType**              | Invalid accept type.
-| **invalidParameterFormat**         | Invalid parameter format.
-| **invalidPath**                    | Name contains invalid characters.
-| **invalidQueryOption**             | Invalid query option.
-| **invalidStartIndex**              | Invalid start index.
-| **lockMismatch**                   | Lock token does not match existing lock.
-| **lockNotFoundOrAlreadyExpired**   | There is currently no unexpired lock on the item.
-| **lockOwnerMismatch**              | Lock Owner ID does not match provided ID.
-| **malformedEntityTag**             | ETag header is malformed. ETags must be quoted strings.
-| **maxDocumentCountExceeded**       | Max limit on number of Documents is reached.
-| **maxFileSizeExceeded**            | Max file size exceeded.
-| **maxFolderCountExceeded**         | Max limit on number of Folders is reached.
-| **maxFragmentLengthExceeded**      | Max file size exceeded.
-| **maxItemCountExceeded**           | Max limit on number of Items is reached.
-| **maxQueryLengthExceeded**         | Max query length exceeded.
-| **maxStreamSizeExceeded**          | Maximum stream size exceeded.
-| **parameterIsTooLong**             | Parameter exceeds maximum length.
-| **parameterIsTooSmall**            | Parameter is smaller than minimum value.
-| **pathIsTooLong**                  | Path exceeds maximum length.
-| **pathTooDeep**                    | Folder hierarchy depth limit reached.
-| **propertyNotUpdateable**          | Property not updateable.
-| **provisioningNotAllowed**         | Request requires account provisioning, which is not allowed.
-| **resourceBeingProvisioned**       | Requested resource is being provisioned.
-| **resyncApplyDifferences**         | Resync required. Replace any local items with the server's version (including deletes) if you're sure that the service was up to date with your local changes when you last sync'd. Upload any local changes that the server doesn't know about.
-| **resyncRequired**                 | Resync is required.
-| **resyncUploadDifferences**        | Resync required. Upload any local items that the service did not return, and upload any files that differ from the server's version (keeping both copies if you're not sure which one is more up-to-date).
-| **serviceNotAvailable**            | The server is unable to process the current request.
-| **serviceReadOnly**                | Resource is temporarily read-only.
-| **throttledRequest**               | Too many requests.
-| **tooManyResultsRequested**        | Too many results requested.
-| **tooManyTermsInQuery**            | Too many terms in the query.
-| **totalAffectedItemCountExceeded** | Operation is not allowed because the number of affected items exceeds threshold.
-| **truncationNotAllowed**           | Data truncation is not allowed.
-| **uploadSessionFailed**            | Upload session failed.
-| **uploadSessionIncomplete**        | Upload session incomplete.
-| **uploadSessionNotFound**          | Upload session not found.
-| **virusSuspicious**                | This document is suspicious and may have a virus.
-| **zeroOrFewerResultsRequested**    | Zero or fewer results requested.
+The `details` property is an optional array of error objects using the same JSON format as the top-level error object.
+In the case of a request that is composed of multiple operations, such as a bulk or batch operation, it may be nece3ssary to return an independent error for each operation.  In this case, the `details` list will be populated with these individual errors.
 
 <!-- {
   "type": "#page.annotation",

--- a/concepts/errors.md
+++ b/concepts/errors.md
@@ -91,31 +91,31 @@ The error resource is composed of a single resource:
 |:---------------|:-----------------------|:-----------------------------------------------------------------------------------------------------------|
 | **code**       | string                 | An error code string for the error that occurred                                                            |
 | **message**    | string                 | A developer ready message about the error that occurred. This should not be displayed to the user directly. |
-| **innererror** | error object           | Optional. An additional error object that may be more specific than the top level error.                     |
-| **details**    | error object           | Optional. A list of additional error objects that may provide a breakdown of multiple errors encountered whilst processing the request. |
+| **innererror** | error object           | Optional. An additional error object that might be more specific than the top-level error.                     |
+| **details**    | error object           | Optional. A list of additional error objects that might provide a breakdown of multiple errors encountered while processing the request. |
 
 <!--<a name="msg_properties"> </a> -->
 
 #### Properties
 
-The `code` property contains a machine-readable value that you can take a dependency on in your code.  
+The **code** property contains a machine-readable value that you can take a dependency on in your code.  
 
-The `innererror` object might recursively contain more `innererror` objects
-with additional, more specific error `codes` properties. When handling an error, apps
-should loop through all the nested error codes available and use the most detailed
+The **innererror** object might recursively contain more **innererror** objects
+with additional, more specific error **codes** properties. When handling an error, apps
+should loop through all the nested error codes that are available and use the most detailed
 one that they understand.
 
-The 'message' property is a human-readable value describing the error condition.  You should not take any dependency on the content of this value in your code. 
+The **message** property is a human-readable value that describes the error condition. Do not take any dependency on the content of this value in your code. 
 
-The `message` property at the root contains an error message intended for the
+The **message** property at the root contains an error message intended for the
 developer to read. Error messages are not localized and shouldn't be displayed
 directly to the user. When handling errors, your code should not take any dependency on the 
-content of `message` values because they can change at any time, and they often contain
+the **message** property values because they can change at any time, and they often contain
 dynamic information specific to the failed request. You should only code
-against error codes returned in `code` properties.
+against error codes returned in **code** properties.
 
-The `details` property is an optional array of error objects using the same JSON format as the top-level error object.
-In the case of a request that is composed of multiple operations, such as a bulk or batch operation, it may be nece3ssary to return an independent error for each operation.  In this case, the `details` list will be populated with these individual errors.
+The **details** property is an optional array of error objects that have the same JSON format as the top-level error object.
+In the case of a request that is composed of multiple operations, such as a bulk or batch operation, it might be necessary to return an independent error for each operation. In this case, the **details** list will be populated with these individual errors.
 
 <!-- {
   "type": "#page.annotation",


### PR DESCRIPTION
Updated main errors page to be accurate and relevant for Microsoft Graph as a whole.

Previously it was an out-of-date copy of the legacy OneDrive API errors page.