### PR TITLE
Fix a couple of dead links to sample apps

### DIFF
--- a/concepts/toolkit/providers/electron.md
+++ b/concepts/toolkit/providers/electron.md
@@ -85,4 +85,4 @@ To create the app in Azure Active Directory:
 ## Next steps
 
 * Check out the step-by-step tutorial for [building an electron app](../get-started/build-an-electron-app.md).
-* Take a look at a [sample Electron application](https://github.com/microsoftgraph/microsoft-graph-toolkit/tree/main/samples/electron-app) that shows how to use the Electron provider.
+* Take a look at a [sample Electron application](https://github.com/pnp/mgt-samples/tree/main/samples/app/electron-app) that shows how to use the Electron provider.

--- a/concepts/toolkit/providers/proxy.md
+++ b/concepts/toolkit/providers/proxy.md
@@ -15,7 +15,7 @@ Your backend service must expose an API that will be called for every call to Mi
 
 Your API implementation should then call Microsoft Graph on behalf of the user and return the results to the component.
 
-For an implementation example, see the [ASP.NET MVC sample](https://github.com/microsoftgraph/microsoft-graph-toolkit/tree/main/samples/proxy-provider-asp-net-core).
+For an implementation example, see the [ASP.NET MVC sample](https://github.com/pnp/mgt-samples/tree/main/samples/app/proxy-provider-asp-net-core).
 
 To learn more about authentication providers, see [providers](./providers.md).
 


### PR DESCRIPTION
Found a couple more dead links. I grepped for "https://github.com/microsoftgraph/microsoft-graph-toolkit/tree/main/samples/" in all the .md files in this repo and didn't find any other examples to fix.

I found that some of the articles (e.g. [build an electron app](https://learn.microsoft.com/en-us/graph/toolkit/get-started/build-an-electron-app), [sharepoint provider](https://learn.microsoft.com/en-us/graph/toolkit/providers/sharepoint), I think there are a few more) lacked any reference to their samples.

Having these links in the various "Build your first app" and all the provider articles would've saved me a few minutes of clicking around when I was doing my research. If you'd like, I would be happy to commit changes to these files with links for this PR, just let me know!