### PR TITLE
TeamApp Delete no longer accepts AppCatalog.Submit permission

### DIFF
--- a/api-reference/v1.0/api/teamsapp-delete.md
+++ b/api-reference/v1.0/api/teamsapp-delete.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged)|
 |:----------------------------------     |:-------------|
-| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All, Directory.ReadWrite.All** |
+| Delegated (work or school account) | AppCatalog.ReadWrite.All, Directory.ReadWrite.All** |
 | Delegated (personal Microsoft account) | Not supported|
 | Application                            | Not supported. |
 


### PR DESCRIPTION
    The following error was received with the AppCatalog.Submit permission.
   
```bash
curl --location --request DELETE 'https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/76433c3f-0f47-40dd-bd03-6f0d9575c5b7' \
--header 'Authorization: Bearer <token>'
```

```
    {
        "error": {
            "code": "Forbidden",
            "message": "Missing scope permissions on the request. API requires one of 'AppCatalog.ReadWrite.All, Directory.ReadWrite.All'. Scopes on the request 'AppCatalog.Submit, Application.ReadWrite.All, ema
il, openid, profile, User.Read'",
            "innerError": {
                "date": "2023-09-04T05:09:22",
                "request-id": "45c5f5d6-5841-42bc-ba6a-8c22ab902152",
                "client-request-id": "45c5f5d6-5841-42bc-ba6a-8c22ab902152"
            }
        }
    }
```