### PR TITLE
Removed reference to $expand

### DIFF
--- a/api-reference/v1.0/api/bookingbusiness-list.md
+++ b/api-reference/v1.0/api/bookingbusiness-list.md
@@ -35,7 +35,7 @@ GET /solutions/bookingBusinesses
 
 ## Optional query parameters
 
-This method supports the `$count` and `$expand` [OData query parameters](/graph/query-parameters) to help customize the response.
+This method supports the `$count` [OData query parameter](/graph/query-parameters) to help customize the response.
 
 This method also supports the `query` parameter which accepts a string value. This parameter limits the GET results to businesses that match the specified string. For more details, see [Example 2](#example-2-use-query-to-get-one-or-more-matching-bookings-businesses-in-a-tenant).
 


### PR DESCRIPTION
While expand shows as an option in the Graph Explorer, any attempt to use it results the following error message: "The query specified in the URI is not valid. Query option 'Expand' is not allowed. To allow it, set the 'AllowedQueryOptions' property on EnableQueryAttribute or QueryValidationSettings."