### PR TITLE
Removed reference to $expand

### DIFF
--- a/api-reference/v1.0/api/bookingbusiness-get.md
+++ b/api-reference/v1.0/api/bookingbusiness-get.md
@@ -29,7 +29,7 @@ GET /solutions/bookingBusinesses/{id}
 
 ## Optional query parameters
 
-This method supports the $count [OData query parameter](/graph/query-parameters) to help customize the response.
+This method supports the `$count` [OData query parameter](/graph/query-parameters) to help customize the response.
 
 ## Request headers
 

--- a/api-reference/v1.0/api/bookingbusiness-get.md
+++ b/api-reference/v1.0/api/bookingbusiness-get.md
@@ -29,7 +29,7 @@ GET /solutions/bookingBusinesses/{id}
 
 ## Optional query parameters
 
-This method supports the $count and $expand [OData query parameters](/graph/query-parameters) to help customize the response.
+This method supports the $count [OData query parameter](/graph/query-parameters) to help customize the response.
 
 ## Request headers
 


### PR DESCRIPTION
While expand shows as an option in the Graph Explorer, any attempt to use it results the following error message: "The query specified in the URI is not valid. Query option 'Expand' is not allowed. To allow it, set the 'AllowedQueryOptions' property on EnableQueryAttribute or QueryValidationSettings."