### PR TITLE
Update Group (Directory) Settings page

### DIFF
--- a/concepts/group-directory-settings.md
+++ b/concepts/group-directory-settings.md
@@ -32,9 +32,7 @@ For groups, only settings for Microsoft 365 groups are available. The following 
 
 ## Group.Unified
 
-The settings in this object specify whether guests can be added to all or specific Microsoft 365 groups in the tenant.
-
-Only one setting is available in this collection.
+This object specifies Microsoft 365 group settings for your tenant.
 
 Unless otherwise indicated, these features require an Azure AD P1 license.
 
@@ -50,7 +48,7 @@ Unless otherwise indicated, these features require an Azure AD P1 license.
 | EnableGroupCreation | Boolean | Indicates whether non-admin users can create Microsoft 365 groups. The default setting is `true`. This setting doesn't require an Azure AD P1 license. This setting corresponds to the _Users can create Microsoft 365 groups in Azure portals, API or PowerShell_ setting in the [group settings menu in the Azure portal](/azure/active-directory/enterprise-users/groups-self-service-management). <br/><br/> **Note:** _The Users can create security groups in Azure portals, API or PowerShell_ setting is configured through the **allowedToCreateSecurityGroups** property of the [defaultUserRolePermissions](/graph/api/resources/defaultuserrolepermissions) object of the [authorizationPolicy resource type](/graph/api/resources/authorizationpolicy).|
 | EnableMSStandardBlockedWords | Boolean | Deprecated and retired. |
 | EnableMIPLabels | Boolean | Indicates whether Microsoft information protection sensitivity labels published in the Microsoft Purview compliance portal can be applied to Microsoft 365 groups. For more information, see [Assign Sensitivity Labels for Microsoft 365 groups](/azure/active-directory/enterprise-users/groups-assign-sensitivity-labels). |
-| GroupCreationAllowedGroupId | GUID | Identifier of the security group for which the members are allowed to create Microsoft 365 groups even when **EnableGroupCreation** is `false`. |
+| GroupCreationAllowedGroupId | GUID | Identifier of the security group for which the members are allowed to create Microsoft 365 groups even when **EnableGroupCreation** is `false`. This setting doesn't require an Azure AD P1 license. |
 | GuestUsageGuidelinesUrl | String | The URL of a link to the guest usage guidelines. |
 | NewUnifiedGroupWritebackDefault | Boolean | A tenant-wide setting that assigns the default value to the **writebackConfiguration/isEnabled** property of new groups, if the property isn't specified during group creation. This setting is applicable when group writeback is configured in Azure AD Connect. The default value is `true`. <br/><br/>Updating this setting to `false` changes the default writeback behavior for new Microsoft 365 groups, but won't change **writebackConfiguration/isEnabled** property for existing Microsoft 365 groups. For more information about this setting and the group's **writebackConfiguration** property, see [group resource type](/graph/api/resources/group?view=graph-rest-beta&preserve-view=true) |
 | PrefixSuffixNamingRequirement | String | Defines the naming convention configured for Microsoft 365 group names and mail nicknames. Maximum character limit is 64. For more information, see [Enforce a naming policy for Microsoft 365 groups](/azure/active-directory/enterprise-users/groups-naming-policy). |


### PR DESCRIPTION
I noticed some issues with the Group (Directory) Settings concept page.

### Removed the copy/paste description of Group.Unified

The description of **Group.Unified** seemed to have been copy/pasted from **Group.Unified.Guest**. This made the page **very** confusing.

### Mention GroupCreationAllowedGroupId not needing an Azure AD P1 license

The documentation claims that a P1 license is required to modify the **GroupCreationAllowedGroupId** setting, but I successfully modified it on tenant with a **Azure Active Directory Free** license. 

Not sure if there is something wrong with my tenant that allowed me to bypass this restriction or if the resctriction isn't applied.