### PR TITLE
Update verb from PATCH to PUT for Stream type in Example 2

### DIFF
--- a/api-reference/beta/api/organizationalbranding-update.md
+++ b/api-reference/beta/api/organizationalbranding-update.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 
-To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage,use the PUT method. You can't update Stream types with other data types in the same request.
+To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage, use the PUT method. You can't update Stream types with other data types in the same request.
 
 <!-- {
   "blockType": "ignored"

--- a/api-reference/beta/api/organizationalbranding-update.md
+++ b/api-reference/beta/api/organizationalbranding-update.md
@@ -144,7 +144,7 @@ HTTP/1.1 204 No Content
 
 ### Example 2: Update bannerLogo for the default branding
 
-The following request updates the banner logo for the default branding.
+The following request updates the banner logo for the default branding. For all Stream types, a PUT verb is used, and the localization is put into the URL.
 
 #### Request
 
@@ -160,7 +160,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-PATCH https://graph.microsoft.com/beta/organization/d69179bf-f4a4-41a9-a9de-249c0f2efb1d/branding/bannerLogo
+PUT https://graph.microsoft.com/beta/organization/d69179bf-f4a4-41a9-a9de-249c0f2efb1d/branding/localizations/0/bannerLogo
 Content-Type: image/jpeg
 
 <Image>

--- a/api-reference/beta/api/organizationalbranding-update.md
+++ b/api-reference/beta/api/organizationalbranding-update.md
@@ -25,12 +25,15 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 
+To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage,use the PUT method. You can't update Stream types with other data types in the same request.
+
 <!-- {
   "blockType": "ignored"
 }
 -->
 ``` http
 PATCH /organization/{organizationId}/branding
+PUT /organization/{organizationId}/branding/localizations/{organizationalBrandingLocalizationId}/{Stream object type such as backgroundImage}
 ```
 
 ## Request headers
@@ -144,7 +147,7 @@ HTTP/1.1 204 No Content
 
 ### Example 2: Update bannerLogo for the default branding
 
-The following request updates the banner logo for the default branding. For all Stream types, a PUT verb is used, and the localization is put into the URL.
+The following request updates the banner logo for the default branding. To update a Stream object type, use the PUT HTTP method and include the locale ID in the URL path.
 
 #### Request
 

--- a/api-reference/beta/api/organizationalbrandinglocalization-update.md
+++ b/api-reference/beta/api/organizationalbrandinglocalization-update.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 
-Only Stream data types, including **backgroundLogo** and **backgroundImage**, are updated using the PUT method. To update String data types, including **signInPageText** and **usernameHintText**, use the PATCH method. You cannot update Stream types with other data types in the same request.
+To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage,use the PUT method. You can't update Stream types with other data types in the same request.
 
 <!-- {
   "blockType": "ignored"
@@ -33,7 +33,8 @@ Only Stream data types, including **backgroundLogo** and **backgroundImage**, ar
 -->
 ``` http
 PATCH /organization/{organizationId}/branding/localizations/{organizationalBrandingLocalizationId}
-PUT /organization/{organizationId}/branding/localizations/{organizationalBrandingLocalizationId}/{backgroundImage | bannerLogo | squareLogo}
+
+PUT /organization/{organizationId}/branding/localizations/{organizationalBrandingLocalizationId}/{Stream object type such as backgroundImage}
 ```
 
 ## Request headers

--- a/api-reference/beta/api/organizationalbrandinglocalization-update.md
+++ b/api-reference/beta/api/organizationalbrandinglocalization-update.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 
-To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage,use the PUT method. You can't update Stream types with other data types in the same request.
+To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage, use the PUT method. You can't update Stream types with other data types in the same request.
 
 <!-- {
   "blockType": "ignored"

--- a/api-reference/v1.0/api/organizationalbranding-update.md
+++ b/api-reference/v1.0/api/organizationalbranding-update.md
@@ -22,13 +22,14 @@ One of the following permissions is required to call this API. To learn more, in
 | Application                            | Not supported. |
 
 ## HTTP request
-
+To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage,use the PUT method. You can't update Stream types with other data types in the same request.
 <!-- {
   "blockType": "ignored"
 }
 -->
 ``` http
 PATCH /organization/{organizationId}/branding
+PUT /organization/{organizationId}/branding/localizations/{organizationalBrandingLocalizationId}/{Stream object type such as backgroundImage}
 ```
 
 ## Request headers
@@ -130,7 +131,7 @@ HTTP/1.1 204 No Content
 
 ### Example 2: Update bannerLogo for default branding
 
-The following request updates the banner logo for the default branding.
+The following request updates the banner logo for the default branding. To update a Stream object type, use the PUT HTTP method and include the locale ID in the URL path.
 
 #### Request
 
@@ -145,7 +146,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-PATCH https://graph.microsoft.com/v1.0/organization/d69179bf-f4a4-41a9-a9de-249c0f2efb1d/branding/bannerLogo
+PUT https://graph.microsoft.com/v1.0/organization/d69179bf-f4a4-41a9-a9de-249c0f2efb1d/branding/localizations/0/bannerLogo
 Content-Type: image/jpeg
 
 <Image>

--- a/api-reference/v1.0/api/organizationalbranding-update.md
+++ b/api-reference/v1.0/api/organizationalbranding-update.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 | Application                            | Not supported. |
 
 ## HTTP request
-To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage,use the PUT method. You can't update Stream types with other data types in the same request.
+To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage, use the PUT method. You can't update Stream types with other data types in the same request.
 <!-- {
   "blockType": "ignored"
 }

--- a/api-reference/v1.0/api/organizationalbrandinglocalization-update.md
+++ b/api-reference/v1.0/api/organizationalbrandinglocalization-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 
-Only Stream data types, including **backgroundLogo** and **backgroundImage**, are updated using the PUT method. To update String data types, including **signInPageText** and **usernameHintText**, use the PATCH method. You cannot update Stream types with other data types in the same request.
+To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage,use the PUT method. You can't update Stream types with other data types in the same request.
 
 <!-- {
   "blockType": "ignored"
@@ -32,7 +32,7 @@ Only Stream data types, including **backgroundLogo** and **backgroundImage**, ar
 ``` http
 PATCH /organization/{organizationId}/branding/localizations/{organizationalBrandingLocalizationId}
 
-PUT /organization/{organizationId}/branding/localizations/{organizationalBrandingLocalizationId}/{backgroundImage | bannerLogo | squareLogo}
+PUT /organization/{organizationId}/branding/localizations/{organizationalBrandingLocalizationId}/{Stream object type such as backgroundImage}
 ```
 
 ## Request headers

--- a/api-reference/v1.0/api/organizationalbrandinglocalization-update.md
+++ b/api-reference/v1.0/api/organizationalbrandinglocalization-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 
-To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage,use the PUT method. You can't update Stream types with other data types in the same request.
+To update String data types, such as signInPageText and usernameHintText, use the PATCH method. To update Stream data types, such as backgroundLogo and backgroundImage, use the PUT method. You can't update Stream types with other data types in the same request.
 
 <!-- {
   "blockType": "ignored"


### PR DESCRIPTION
The documentation incorrectly points users to use a PATCH request for changing Stream types, but a PUT is needed for those types. This issue has been raised in #8580, #2718, and also [here](https://learn.microsoft.com/en-us/answers/questions/407715/update-organizationalbrandingproperties).