### PR TITLE
Correcting the query that is missing a '?' for the 'filter' parameter

### DIFF
--- a/api-reference/beta/api/privilegedaccessgroup-list-eligibilityscheduleinstances.md
+++ b/api-reference/beta/api/privilegedaccessgroup-list-eligibilityscheduleinstances.md
@@ -61,7 +61,7 @@ The following is an example of a request.
 }
 -->
 ``` http
-GET https://graph.microsoft.com/beta/identityGovernance/privilegedAccess/group/eligibilityScheduleInstances$filter=groupId eq '2b5ed229-4072-478d-9504-a047ebd4b07d'
+GET https://graph.microsoft.com/beta/identityGovernance/privilegedAccess/group/eligibilityScheduleInstances?$filter=groupId eq '2b5ed229-4072-478d-9504-a047ebd4b07d'
 ```
 
 


### PR DESCRIPTION
The original query is missing a '?' for the 'filter' parameter, which results in an error in querying. 