### PR TITLE
Add statement that period parameter is mandatory for relyingpartydetailedsummary-list by cewu.md

### DIFF
--- a/api-reference/beta/api/relyingpartydetailedsummary-list.md
+++ b/api-reference/beta/api/relyingpartydetailedsummary-list.md
@@ -36,7 +36,7 @@ GET /reports/getRelyingPartyDetailedSummary(period='period_value')
 
 | Parameter | Description |
 |:----------|:----------|
-| period | **Mandatory**. The supported values are: D1, D7, D30. These values follow the format Dn where n represents the number of days over which the report is aggregated.|
+| period | Required. The supported values are: D1, D7, D30. These values follow the format Dn where n represents the number of days over which the report is aggregated.|
 
 ## Optional query parameters
 

--- a/api-reference/beta/api/relyingpartydetailedsummary-list.md
+++ b/api-reference/beta/api/relyingpartydetailedsummary-list.md
@@ -30,13 +30,13 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-GET /reports/getRelyingPartyDetailedSummary
+GET /reports/getRelyingPartyDetailedSummary(period='period_value')
 ```
 ## Function parameters
 
 | Parameter | Description |
 |:----------|:----------|
-| period | The supported values are: D1, D7, D30. These values follow the format Dn where n represents the number of days over which the report is aggregated.|
+| period | **Mandatory**. The supported values are: D1, D7, D30. These values follow the format Dn where n represents the number of days over which the report is aggregated.|
 
 ## Optional query parameters
 


### PR DESCRIPTION
In the HTTP request, Add statement that the period parameter is mandatory. It helps to avoid confusion as user may try incorrect url without period directly.