### PR TITLE
Update chat-list.md

### DIFF
--- a/api-reference/v1.0/api/chat-list.md
+++ b/api-reference/v1.0/api/chat-list.md
@@ -134,7 +134,7 @@ GET https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5/
 
 #### Response
 
-Here is an example of the response.
+Here is an example of the response. While the "lastUpdatedDateTime" field is available in the initial response from the "https://graph.microsoft.com/v1.0/chats" endpoint, it may not reflect the most current update timestamp accurately. For the most accurate and up-to-date information on the thread's last updated date and time, always use the "$expand=lastMessagePreview" query parameter to fetch the latest "lastUpdatedDateTime" from the "lastMessagePreview" object within the response. This ensures you have the most reliable information when working with chat threads in the Microsoft Graph API. 
 
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {

--- a/api-reference/v1.0/api/chat-list.md
+++ b/api-reference/v1.0/api/chat-list.md
@@ -134,7 +134,9 @@ GET https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5/
 
 #### Response
 
-Here is an example of the response. While the "lastUpdatedDateTime" field is available in the initial response from the "https://graph.microsoft.com/v1.0/chats" endpoint, it may not reflect the most current update timestamp accurately. For the most accurate and up-to-date information on the thread's last updated date and time, always use the "$expand=lastMessagePreview" query parameter to fetch the latest "lastUpdatedDateTime" from the "lastMessagePreview" object within the response. This ensures you have the most reliable information when working with chat threads in the Microsoft Graph API. 
+The following is an example of the response. 
+
+The **lastUpdatedDateTime** field is available in the initial response from the `https://graph.microsoft.com/v1.0/chats` endpoint; however, it might not reflect the most current update timestamp. For the most accurate last updated date and time, use the `$expand=lastMessagePreview` query parameter to fetch the latest **lastUpdatedDateTime** from the **lastMessagePreview** object within the response. This ensures that you have the most reliable information when you work with chat threads. 
 
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {


### PR DESCRIPTION
When making requests to the "https://graph.microsoft.com/v1.0/chats" endpoint within the Microsoft Graph API, it's important to note that the response includes a property named "lastUpdatedDateTime". However, this "lastUpdatedDateTime" field does not necessarily represent the thread's last updated date and time accurately.

To obtain the most up-to-date and accurate information about the last updated date and time of a thread, you should utilize the $expand=lastMessagePreview query parameter when making your API request.

By including the $expand=lastMessagePreview parameter in your API call to "https://graph.microsoft.com/v1.0/chats," you will receive additional information in the response, specifically from the "lastMessagePreview" object. Within this object, you will find the latest and most precise "lastUpdatedDateTime" value associated with the thread.

In summary, while the "lastUpdatedDateTime" field is available in the initial response from the "https://graph.microsoft.com/v1.0/chats" endpoint, it may not reflect the most current update timestamp accurately. For the most accurate and up-to-date information on the thread's last updated date and time, always use the "$expand=lastMessagePreview" query parameter to fetch the latest "lastUpdatedDateTime" from the "lastMessagePreview" object within the response. This ensures that you have the most reliable information when working with chat threads in the Microsoft Graph API.