### PR TITLE
Fix spelling error in profilecardproperty-update.md

### DIFF
--- a/api-reference/beta/api/profilecardproperty-update.md
+++ b/api-reference/beta/api/profilecardproperty-update.md
@@ -65,7 +65,7 @@ If successful, this method returns a `200 OK` response code and an updated [prof
 
 ### Request
 
-The following example adds a localized label `Kostnads Senter` for the locale `no-NB`.
+The following example adds a localized label `Kostnadssenter` for the locale `no-NB`.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -84,7 +84,7 @@ Content-type: application/json; charset=utf-8
       "localizations": [
         {
           "languageTag": "no-NB",
-          "displayName": "Kostnads Senter"
+          "displayName": "Kostnadssenter"
         }
       ]
     }
@@ -154,7 +154,7 @@ Content-type: application/json; charset=utf-8
         },
         {
           "languageTag": "no-NB",
-          "displayName": "Kostnads Senter"
+          "displayName": "Kostnadssenter"
         }
       ]
     }


### PR DESCRIPTION
The Norwegian word `kostnadssenter` was spelled incorrectly.