### PR TITLE
Adding roles allowed to add a federation configuration

### DIFF
--- a/api-reference/beta/api/domain-post-federationconfiguration.md
+++ b/api-reference/beta/api/domain-post-federationconfiguration.md
@@ -23,10 +23,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 <!-- { "blockType": "permissions", "name": "domain_post_federationconfiguration" } -->
 [!INCLUDE [permissions-table](../includes/permissions/domain-post-federationconfiguration-permissions.md)]
 
-The calling user must be assigned one of the following [Microsoft Entra roles](/azure/active-directory/roles/permissions-reference?toc=%2Fgraph%2Ftoc.json):
-
-- Security Administrator
-- External Identity Provider Administrator
+[!INCLUDE [rbac-domainfederation-apis-write](../includes/rbac-for-apis/rbac-domainfederation-apis-write.md)]
 
 ## HTTP request
 

--- a/api-reference/beta/includes/rbac-for-apis/rbac-domainfederation-apis-write.md
+++ b/api-reference/beta/includes/rbac-for-apis/rbac-domainfederation-apis-write.md
@@ -1,0 +1,10 @@
+---
+author: rahul-nagraj
+ms.topic: include
+---
+
+For delegated scenarios, the calling user must be assigned at least one of the following [Microsoft Entra roles](/azure/active-directory/roles/permissions-reference?toc=%2Fgraph%2Ftoc.json):
+
+- External Identity Provider Administrator
+- Domain Name Administrator
+- Security Administrator

--- a/api-reference/v1.0/api/domain-post-federationconfiguration.md
+++ b/api-reference/v1.0/api/domain-post-federationconfiguration.md
@@ -21,13 +21,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 <!-- { "blockType": "permissions", "name": "domain_post_federationconfiguration" } -->
 [!INCLUDE [permissions-table](../includes/permissions/domain-post-federationconfiguration-permissions.md)]
 
-The calling user must be assigned one of the following [Microsoft Entra roles](/azure/active-directory/roles/permissions-reference?toc=%2Fgraph%2Ftoc.json):
-
-- Global Administrator
-- Security Administrator
-- External Identity Provider Administrator
-- Domain Name Administrator
-- Partner Tier2 Support
+[!INCLUDE [rbac-domainfederation-apis-write](../includes/rbac-for-apis/rbac-domainfederation-apis-write.md)]
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/domain-post-federationconfiguration.md
+++ b/api-reference/v1.0/api/domain-post-federationconfiguration.md
@@ -23,8 +23,11 @@ Choose the permission or permissions marked as least privileged for this API. Us
 
 The calling user must be assigned one of the following [Microsoft Entra roles](/azure/active-directory/roles/permissions-reference?toc=%2Fgraph%2Ftoc.json):
 
+- Global Administrator
 - Security Administrator
 - External Identity Provider Administrator
+- Domain Name Administrator
+- Partner Tier2 Support
 
 ## HTTP request
 

--- a/api-reference/v1.0/includes/rbac-for-apis/rbac-domainfederation-apis-write.md
+++ b/api-reference/v1.0/includes/rbac-for-apis/rbac-domainfederation-apis-write.md
@@ -1,0 +1,10 @@
+---
+author: rahul-nagraj
+ms.topic: include
+---
+
+For delegated scenarios, the calling user must be assigned at least one of the following [Microsoft Entra roles](/azure/active-directory/roles/permissions-reference?toc=%2Fgraph%2Ftoc.json):
+
+- External Identity Provider Administrator
+- Domain Name Administrator
+- Security Administrator


### PR DESCRIPTION
My tests have shown that a user with any of these three roles is also allowed to add a federation configuration.

The reproduction steps is to:
- create a user for each role
- assign the role to the user
- obtain a Graph API token for the user
- attempt to add a federation configuration
- see that it works!