### PR TITLE
Fix the OData bind syntax for the python SDK

### DIFF
--- a/api-reference/v1.0/includes/snippets/python/create-prepopulated-group-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-prepopulated-group-python-snippets.md
@@ -17,10 +17,10 @@ request_body = Group(
 	mail_nickname = "operations2019",
 	security_enabled = True,
 	additional_data = {
-			"owners@odata_bind" : [
+			"owners@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/26be1845-4119-4801-a799-aea79d09f1a2",
 			],
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/ff7cb387-6688-423c-8188-3da9532a73cc",
 				"https://graph.microsoft.com/v1.0/users/69456242-0067-49d3-ba96-9de6f2728e14",
 			],


### PR DESCRIPTION
- Replacing the underscore in the odata bind annotation with a dot. 
- This leads to the expected behaviour, i.e. the group is created with an owner and members.