### PR TITLE
Fix the OData bind syntax for the python SDK

### DIFF
--- a/api-reference/beta/includes/snippets/python/add-app-in-chat-beta-e1-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/add-app-in-chat-beta-e1-python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = TeamsAppInstallation(
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/add-app-in-chat-beta-e2-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/add-app-in-chat-beta-e2-python-snippets.md
@@ -30,7 +30,7 @@ request_body = TeamsAppInstallation(
 		],
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/2b524e28-95ce-4c9b-9773-4a5bd6ec1770",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/2b524e28-95ce-4c9b-9773-4a5bd6ec1770",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/add-app-in-team-e1-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/add-app-in-team-e1-python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = TeamsAppInstallation(
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/add-app-in-team-e2-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/add-app-in-team-e2-python-snippets.md
@@ -22,7 +22,7 @@ request_body = TeamsAppInstallation(
 		],
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/7023576d-9e40-47ca-9cf2-daae6838e785",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/7023576d-9e40-47ca-9cf2-daae6838e785",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/add-tab-to-chat-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/add-tab-to-chat-python-snippets.md
@@ -17,7 +17,7 @@ request_body = TeamsTab(
 		remove_url = "https://www.contoso.com/Orders/2DCA2E6C7A10415CAF6B8AB6661B3154/uninstallTab",
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/06805b9e-77e3-4b93-ac81-525eb87513b8",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/06805b9e-77e3-4b93-ac81-525eb87513b8",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/bulkaddmembers-team-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/bulkaddmembers-team-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AddPostRequestBody(
 			roles = [
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('18a80140-b0fb-4489-b360-2f6efaf225a0')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('18a80140-b0fb-4489-b360-2f6efaf225a0')",
 			}
 		),
 		AadUserConversationMember(
@@ -24,7 +24,7 @@ request_body = AddPostRequestBody(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('86503198-b81b-43fe-81ee-ad45b8848ac9')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('86503198-b81b-43fe-81ee-ad45b8848ac9')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/bulkaddmembers-team-upn-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/bulkaddmembers-team-upn-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AddPostRequestBody(
 			roles = [
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
 			}
 		),
 		AadUserConversationMember(
@@ -24,7 +24,7 @@ request_body = AddPostRequestBody(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('alex@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('alex@contoso.com')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/channel-add-member-1-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/channel-add-member-1-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/channel-add-member-2-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/channel-add-member-2-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/channel-add-member-3-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/channel-add-member-3-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/channel-add-member-e6-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/channel-add-member-e6-python-snippets.md
@@ -13,7 +13,7 @@ request_body = AadUserConversationMember(
 	roles = [
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/convert-team-from-group-e5-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/convert-team-from-group-e5-python-snippets.md
@@ -29,18 +29,18 @@ request_body = Team(
 	installed_apps = [
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
 			}
 		),
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
-			"group@odata_bind" : "https://graph.microsoft.com/beta/groups('dbd8de4f-5d47-48da-87f1-594bed003375')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+			"group@odata.bind" : "https://graph.microsoft.com/beta/groups('dbd8de4f-5d47-48da-87f1-594bed003375')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/convert-team-from-non-standard-e6-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/convert-team-from-non-standard-e6-python-snippets.md
@@ -12,7 +12,7 @@ request_body = Team(
 	display_name = "My Class Team",
 	description = "My Class Team’s Description",
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('educationClass')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('educationClass')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/convert-team-from-non-standard2-e8-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/convert-team-from-non-standard2-e8-python-snippets.md
@@ -31,17 +31,17 @@ request_body = Team(
 	installed_apps = [
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
 			}
 		),
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('educationClass')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('educationClass')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-a-group-chat-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-a-group-chat-python-snippets.md
@@ -18,7 +18,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')",
 			}
 		),
 		AadUserConversationMember(
@@ -27,7 +27,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')",
 			}
 		),
 		AadUserConversationMember(
@@ -36,7 +36,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('3626a173-f2bc-4883-bcf7-01514c3bfb82')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('3626a173-f2bc-4883-bcf7-01514c3bfb82')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-accesspackageresourcerequest-from-accesspackageresourcerequests-with-accesspackageresourceenvironment-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-accesspackageresourcerequest-from-accesspackageresourcerequests-with-accesspackageresourceenvironment-python-snippets.md
@@ -17,7 +17,7 @@ request_body = AccessPackageResourceRequest(
 		origin_id = "https://contoso.sharepoint.com/sites/CSR",
 		origin_system = "SharePointOnline",
 		additional_data = {
-				"access_package_resource_environment@odata_bind" : "accessPackageResourceEnvironments/615f2218-678f-471f-a60a-02c2f4f80c57",
+				"access_package_resource_environment@odata.bind" : "accessPackageResourceEnvironments/615f2218-678f-471f-a60a-02c2f4f80c57",
 		}
 	),
 	request_type = "AdminAdd",

--- a/api-reference/beta/includes/snippets/python/create-azuredatalakeconnector-from-dataconnectors-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-azuredatalakeconnector-from-dataconnectors-python-snippets.md
@@ -12,7 +12,7 @@ request_body = AzureDataLakeConnector(
 	odata_type = "#microsoft.graph.industryData.azureDataLakeConnector",
 	display_name = "CSV connector",
 	additional_data = {
-			"source_system@odata_bind" : "https://graph.microsoft.com/beta/external/industryData/sourceSystems('aa050107-5784-4a8e-1876-08daddab21bc')",
+			"source_system@odata.bind" : "https://graph.microsoft.com/beta/external/industryData/sourceSystems('aa050107-5784-4a8e-1876-08daddab21bc')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-chat-group-with-tenant-guest-user-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-chat-group-with-tenant-guest-user-python-snippets.md
@@ -18,7 +18,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')",
 			}
 		),
 		AadUserConversationMember(
@@ -27,7 +27,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')",
 			}
 		),
 		AadUserConversationMember(
@@ -36,7 +36,7 @@ request_body = Chat(
 				"guest",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-chat-oneonone-federated-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-chat-oneonone-federated-python-snippets.md
@@ -17,7 +17,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 			}
 		),
 		AadUserConversationMember(
@@ -27,7 +27,7 @@ request_body = Chat(
 			],
 			tenant_id = "4dc1fe35-8ac6-4f0d-904a-7ebcd364bea1",
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-chat-oneonone-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-chat-oneonone-python-snippets.md
@@ -17,7 +17,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 			}
 		),
 		AadUserConversationMember(
@@ -26,7 +26,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-chat-oneonone-upn-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-chat-oneonone-upn-python-snippets.md
@@ -17,7 +17,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
 			}
 		),
 		AadUserConversationMember(
@@ -26,7 +26,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('alex@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('alex@contoso.com')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-chat-oneonone-with-installed-apps-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-chat-oneonone-with-installed-apps-python-snippets.md
@@ -17,7 +17,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 			}
 		),
 		AadUserConversationMember(
@@ -26,14 +26,14 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
 			}
 		),
 	],
 	installed_apps = [
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/05F59CEC-A742-4A50-A62E-202A57E478A4",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/05F59CEC-A742-4A50-A62E-202A57E478A4",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-conversation-member-upn-5-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-conversation-member-upn-5-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users/jacob@contoso.com",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users/jacob@contoso.com",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-conversation-member-with-all-visiblehistorystartdatetime-3-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-conversation-member-with-all-visiblehistorystartdatetime-3-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-2-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-2-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-5-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-5-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"guest",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users/8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users/8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-6-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-6-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AadUserConversationMember(
 	],
 	tenant_id = "4dc1fe35-8ac6-4f0d-904a-7ebcd364bea1",
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users/82af01c5-f7cc-4a2e-a728-3a5df21afd9d",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users/82af01c5-f7cc-4a2e-a728-3a5df21afd9d",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-conversation-member-with-specific-visiblehistorystartdatetime-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-conversation-member-with-specific-visiblehistorystartdatetime-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-conversationmember-from--python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-conversationmember-from--python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-conversationmember-upn-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-conversationmember-upn-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-ediscoveryholdpolicy-from--python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-ediscoveryholdpolicy-from--python-snippets.md
@@ -12,13 +12,13 @@ request_body = EdiscoveryHoldPolicy(
 	display_name = "My legalHold with sources",
 	description = "Created from Graph API",
 	additional_data = {
-			"user_sources@odata_bind" : [
+			"user_sources@odata.bind" : [
 				{
 						"@odata_type" : "microsoft.graph.security.userSource",
 						"email" : "SalesTeam@M365x809305.OnMicrosoft.com",
 				},
 			],
-			"site_sources@odata_bind" : [
+			"site_sources@odata.bind" : [
 				{
 						"@odata_type" : "microsoft.graph.security.siteSource",
 						"site" : {

--- a/api-reference/beta/includes/snippets/python/create-ediscoverysearch-from--python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-ediscoverysearch-from--python-snippets.md
@@ -13,12 +13,12 @@ request_body = EdiscoverySearch(
 	description = "My first search",
 	content_query = "(Author=\"edison\")",
 	additional_data = {
-			"custodian_sources@odata_bind" : [
+			"custodian_sources@odata.bind" : [
 				"https://graph.microsoft.com/beta/security/cases/ediscoveryCases/b0073e4e-4184-41c6-9eb7-8c8cc3e2288b/custodians/0053a61a3b6c42738f7606791716a22a/userSources/43434642-3137-3138-3432-374142313639",
 				"https://graph.microsoft.com/beta/security/cases/ediscoveryCases/b0073e4e-4184-41c6-9eb7-8c8cc3e2288b/custodians/0053a61a3b6c42738f7606791716a22a/siteSources/169718e3-a8df-449d-bef4-ee09fe1ddc5d",
 				"https://graph.microsoft.com/beta/security/cases/ediscoveryCases('b0073e4e-4184-41c6-9eb7-8c8cc3e2288b')/custodians('0053a61a3b6c42738f7606791716a22a')/unifiedGroupSources('32e14fa4-3106-4bd2-a245-34bf0c718a7e')",
 			],
-			"noncustodial_sources@odata_bind" : [
+			"noncustodial_sources@odata.bind" : [
 				"https://graph.microsoft.com/beta/security/cases/ediscoveryCases/b0073e4e-4184-41c6-9eb7-8c8cc3e2288b/noncustodialdatasources/35393639323133394345384344303043",
 			],
 	}

--- a/api-reference/beta/includes/snippets/python/create-inboundfileflow-from-inboundflows-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-inboundfileflow-from-inboundflows-python-snippets.md
@@ -15,8 +15,8 @@ request_body = InboundFileFlow(
 	effective_date_time = "2023-03-12T16:40:46.924769+05:30",
 	expiration_date_time = "2023-03-13T16:40:46.924769+05:30",
 	additional_data = {
-			"data_connector@odata_bind" : "https://graph.microsoft.com/beta/external/industryData/dataConnectors/51dca0a0-85f6-4478-f526-08daddab2271",
-			"year@odata_bind" : "https://graph.microsoft.com/beta/external/industryData/years/ebf18762-ab92-487e-21d1-08daddab28bb",
+			"data_connector@odata.bind" : "https://graph.microsoft.com/beta/external/industryData/dataConnectors/51dca0a0-85f6-4478-f526-08daddab2271",
+			"year@odata.bind" : "https://graph.microsoft.com/beta/external/industryData/years/ebf18762-ab92-487e-21d1-08daddab28bb",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-inboundflow-from-inboundflows-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-inboundflow-from-inboundflows-python-snippets.md
@@ -15,8 +15,8 @@ request_body = InboundFileFlow(
 	effective_date_time = "2023-03-12T16:40:46.924769+05:30",
 	expiration_date_time = "2023-03-13T16:40:46.924769+05:30",
 	additional_data = {
-			"data_connector@odata_bind" : "https://graph.microsoft.com/beta/external/industryData/dataConnectors/51dca0a0-85f6-4478-f526-08daddab2271",
-			"year@odata_bind" : "https://graph.microsoft.com/beta/external/industryData/years/ebf18762-ab92-487e-21d1-08daddab28bb",
+			"data_connector@odata.bind" : "https://graph.microsoft.com/beta/external/industryData/dataConnectors/51dca0a0-85f6-4478-f526-08daddab2271",
+			"year@odata.bind" : "https://graph.microsoft.com/beta/external/industryData/years/ebf18762-ab92-487e-21d1-08daddab28bb",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-industrydataconnector-from-dataconnectors-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-industrydataconnector-from-dataconnectors-python-snippets.md
@@ -12,7 +12,7 @@ request_body = AzureDataLakeConnector(
 	odata_type = "#microsoft.graph.industryData.azureDataLakeConnector",
 	display_name = "CSV connector",
 	additional_data = {
-			"source_system@odata_bind" : "https://graph.microsoft.com/beta/external/industryData/sourceSystems('aa050107-5784-4a8e-1876-08daddab21bc')",
+			"source_system@odata.bind" : "https://graph.microsoft.com/beta/external/industryData/sourceSystems('aa050107-5784-4a8e-1876-08daddab21bc')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-pinnedchatmessageinfo-from--python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-pinnedchatmessageinfo-from--python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = PinnedChatMessageInfo(
 	additional_data = {
-			"message@odata_bind" : "https://graph.microsoft.com/beta/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1616964509832",
+			"message@odata.bind" : "https://graph.microsoft.com/beta/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1616964509832",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-prepopulated-group-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-prepopulated-group-python-snippets.md
@@ -17,10 +17,10 @@ request_body = Group(
 	mail_nickname = "operations2019",
 	security_enabled = True,
 	additional_data = {
-			"owners@odata_bind" : [
+			"owners@odata.bind" : [
 				"https://graph.microsoft.com/beta/users/26be1845-4119-4801-a799-aea79d09f1a2",
 			],
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/beta/users/ff7cb387-6688-423c-8188-3da9532a73cc",
 				"https://graph.microsoft.com/beta/users/69456242-0067-49d3-ba96-9de6f2728e14",
 			],

--- a/api-reference/beta/includes/snippets/python/create-printer-tasktrigger-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-printer-tasktrigger-python-snippets.md
@@ -11,7 +11,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 request_body = PrintTaskTrigger(
 	event = PrintEvent.JobStarted,
 	additional_data = {
-			"definition@odata_bind" : "https://graph.microsoft.com/beta/print/taskDefinitions/3203656e-6069-4e10-8147-d25290b00a3c",
+			"definition@odata.bind" : "https://graph.microsoft.com/beta/print/taskDefinitions/3203656e-6069-4e10-8147-d25290b00a3c",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-printershare-from-print-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-printershare-from-print-python-snippets.md
@@ -11,7 +11,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 request_body = PrinterShare(
 	name = "name-value",
 	additional_data = {
-			"printer@odata_bind" : "https://graph.microsoft.com/beta/print/printers/{id}",
+			"printer@odata.bind" : "https://graph.microsoft.com/beta/print/printers/{id}",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-private-channel-upn-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-private-channel-upn-python-snippets.md
@@ -20,7 +20,7 @@ request_body = Channel(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-private-channel-with-member-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-private-channel-with-member-python-snippets.md
@@ -20,7 +20,7 @@ request_body = Channel(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('62855810-484b-4823-9e01-60667f8b12ae')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('62855810-484b-4823-9e01-60667f8b12ae')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-retentionlabel-from--python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-retentionlabel-from--python-snippets.md
@@ -27,11 +27,11 @@ request_body = RetentionLabel(
 	default_record_behavior = DefaultRecordBehavior.StartLocked,
 	descriptors = FilePlanDescriptor(
 		additional_data = {
-				"authority_template@odata_bind" : "https://graph.microsoft.com/beta/security/labels/authorities('fie3f4fc-b966-4c40-94de-fb8a383658e4')",
-				"category_template@odata_bind" : "https://graph.microsoft.com/beta/security/labels/categories('0bjk8-b966-4c40-94de-fb8a383658e4')",
-				"citation_template@odata_bind" : "https://graph.microsoft.com/beta/security/labels/citations('0e23f4fc-b966-4c40-94de-fb8a383658e4')",
-				"department_template@odata_bind" : "https://graph.microsoft.com/beta/security/labels/departments('p99ef4fc-b966-4c40-94de-fb8a383658e4')",
-				"file_plan_reference_template@odata_bind" : "https://graph.microsoft.com/beta/security/labels/filePlanReferences('e095f4fc-b966-4c40-94de-fb8a383658e4')",
+				"authority_template@odata.bind" : "https://graph.microsoft.com/beta/security/labels/authorities('fie3f4fc-b966-4c40-94de-fb8a383658e4')",
+				"category_template@odata.bind" : "https://graph.microsoft.com/beta/security/labels/categories('0bjk8-b966-4c40-94de-fb8a383658e4')",
+				"citation_template@odata.bind" : "https://graph.microsoft.com/beta/security/labels/citations('0e23f4fc-b966-4c40-94de-fb8a383658e4')",
+				"department_template@odata.bind" : "https://graph.microsoft.com/beta/security/labels/departments('p99ef4fc-b966-4c40-94de-fb8a383658e4')",
+				"file_plan_reference_template@odata.bind" : "https://graph.microsoft.com/beta/security/labels/filePlanReferences('e095f4fc-b966-4c40-94de-fb8a383658e4')",
 		}
 	),
 )

--- a/api-reference/beta/includes/snippets/python/create-role-enabled-group-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-role-enabled-group-python-snippets.md
@@ -19,10 +19,10 @@ request_body = Group(
 	security_enabled = True,
 	mail_nickname = "contosohelpdeskadministrators",
 	additional_data = {
-			"owners@odata_bind" : [
+			"owners@odata.bind" : [
 				"https://graph.microsoft.com/beta/users/99e44b05-c10b-4e95-a523-e2732bbaba1e",
 			],
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/beta/users/6ea91a8d-e32e-41a1-b7bd-d2d185eed0e0",
 				"https://graph.microsoft.com/beta/users/4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
 			],

--- a/api-reference/beta/includes/snippets/python/create-shared-channel-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-shared-channel-python-snippets.md
@@ -19,7 +19,7 @@ request_body = Channel(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('7640023f-fe43-gv3f-9gg4-84a9efe4acd6')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('7640023f-fe43-gv3f-9gg4-84a9efe4acd6')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-simulations-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-simulations-python-snippets.md
@@ -37,15 +37,15 @@ request_body = Simulation(
 		additional_data = {
 				"simulation_notification" : {
 						"targetted_user_type" : "compromised",
-						"end_user_notification@odata_bind" : "https://graph.microsoft.com/beta/security/attacksimulation/endUserNotifications/12wer3678-9abc-def0-123456789a",
+						"end_user_notification@odata.bind" : "https://graph.microsoft.com/beta/security/attacksimulation/endUserNotifications/12wer3678-9abc-def0-123456789a",
 						"default_language" : "en",
 				},
 		}
 	),
 	additional_data = {
-			"payload@odata_bind" : "https://graph.microsoft.com/beta/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
-			"login_page@odata_bind" : "https://graph.microsoft.com/beta/security/attacksimulation/loginPages/1w345678-9abc-def0-123456789a",
-			"landing_page@odata_bind" : "https://graph.microsoft.com/beta/security/attacksimulation/landingPages/1c345678-9abc-def0-123456789a",
+			"payload@odata.bind" : "https://graph.microsoft.com/beta/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
+			"login_page@odata.bind" : "https://graph.microsoft.com/beta/security/attacksimulation/loginPages/1w345678-9abc-def0-123456789a",
+			"landing_page@odata.bind" : "https://graph.microsoft.com/beta/security/attacksimulation/landingPages/1c345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-sourcecollection-from--python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-sourcecollection-from--python-snippets.md
@@ -12,7 +12,7 @@ request_body = SourceCollection(
 	display_name = "Quarterly Financials search",
 	content_query = "subject:'Quarterly Financials'",
 	additional_data = {
-			"custodian_sources@odata_bind" : [
+			"custodian_sources@odata.bind" : [
 				"https://graph.microsoft.com/beta/compliance/ediscovery/cases/47746044-fd0b-4a30-acfc-5272b691ba5b/custodians/2192ca408ea2410eba3bec8ae873be6b/userSources/46384443-4137-3032-3437-363939433735",
 			],
 	}

--- a/api-reference/beta/includes/snippets/python/create-sourcesystemdefinition-from-sourcesystems-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-sourcesystemdefinition-from-sourcesystems-python-snippets.md
@@ -20,7 +20,7 @@ request_body = SourceSystemDefinition(
 				code = "username",
 			),
 			additional_data = {
-					"role_group@odata_bind" : "https://graph.microsoft.com/beta/external/industryData/roleGroups/staff",
+					"role_group@odata.bind" : "https://graph.microsoft.com/beta/external/industryData/roleGroups/staff",
 			}
 		),
 		UserMatchingSetting(
@@ -32,7 +32,7 @@ request_body = SourceSystemDefinition(
 				code = "username",
 			),
 			additional_data = {
-					"role_group@odata_bind" : "https://graph.microsoft.com/beta/external/industryData/roleGroups('students')",
+					"role_group@odata.bind" : "https://graph.microsoft.com/beta/external/industryData/roleGroups('students')",
 			}
 		),
 	],

--- a/api-reference/beta/includes/snippets/python/create-tag-from--python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-tag-from--python-snippets.md
@@ -12,7 +12,7 @@ request_body = Tag(
 	display_name = "Privileged",
 	description = "The document is privileged",
 	additional_data = {
-			"parent@odata_bind" : "https://graph.microsoft.com/beta/compliance/ediscovery/cases/47746044-fd0b-4a30-acfc-5272b691ba5b/tags/98fdad78bbce4519b75474bc150575c3",
+			"parent@odata.bind" : "https://graph.microsoft.com/beta/compliance/ediscovery/cases/47746044-fd0b-4a30-acfc-5272b691ba5b/tags/98fdad78bbce4519b75474bc150575c3",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-team-from-group-e4-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-team-from-group-e4-python-snippets.md
@@ -10,8 +10,8 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = Team(
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
-			"group@odata_bind" : "https://graph.microsoft.com/beta/groups('71392b2f-1765-406e-86af-5907d9bdb2ab')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+			"group@odata.bind" : "https://graph.microsoft.com/beta/groups('71392b2f-1765-406e-86af-5907d9bdb2ab')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-team-in-migration-mode-e9-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-team-in-migration-mode-e9-python-snippets.md
@@ -14,7 +14,7 @@ request_body = Team(
 	created_date_time = "2020-03-14T11:22:17.067Z",
 	additional_data = {
 			"@microsoft_graph_team_creation_mode" : "migration",
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-team-post-e1-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-team-post-e1-python-snippets.md
@@ -12,7 +12,7 @@ request_body = Team(
 	display_name = "My Sample Team",
 	description = "My Sample Team’s Description",
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-team-post-full-payload-e3-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-team-post-full-payload-e3-python-snippets.md
@@ -29,7 +29,7 @@ request_body = Team(
 						content_url = "https://learn.microsoft.com/microsoftteams/microsoft-teams",
 					),
 					additional_data = {
-							"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.web')",
+							"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.web')",
 					}
 				),
 				TeamsTab(
@@ -39,7 +39,7 @@ request_body = Team(
 						website_url = "https://www.youtube.com/watch?v=X8krAMdGvCQ",
 					),
 					additional_data = {
-							"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.youtube')",
+							"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.youtube')",
 					}
 				),
 			],
@@ -84,17 +84,17 @@ request_body = Team(
 	installed_apps = [
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
 			}
 		),
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-team-post-minimal-e2-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-team-post-minimal-e2-python-snippets.md
@@ -18,12 +18,12 @@ request_body = Team(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('0040b377-61d8-43db-94f5-81374122dc7e')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('0040b377-61d8-43db-94f5-81374122dc7e')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-team-post-upn-e10-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-team-post-upn-e10-python-snippets.md
@@ -18,12 +18,12 @@ request_body = Team(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/beta/users('jacob@contoso.com')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/beta/teamsTemplates('standard')",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-tqag-with-a-parent-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-tqag-with-a-parent-python-snippets.md
@@ -13,7 +13,7 @@ request_body = EdiscoveryReviewTag(
 	description = "Use Graph API to create tags",
 	child_selectability = ChildSelectability.Many,
 	additional_data = {
-			"parent@odata_bind" : "",
+			"parent@odata.bind" : "",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-unifiedgroupsource-from-id-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-unifiedgroupsource-from-id-python-snippets.md
@@ -11,7 +11,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 request_body = UnifiedGroupSource(
 	included_sources = SourceType.Mailbox | SourceType.Site,
 	additional_data = {
-			"group@odata_bind" : "https://graph.microsoft.com/v1.0/groups/b96f95c5-b1b3-4142-b039-8ac79e7d2c84",
+			"group@odata.bind" : "https://graph.microsoft.com/v1.0/groups/b96f95c5-b1b3-4142-b039-8ac79e7d2c84",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/create-unifiedgroupsource-withgroup-odata-bind-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/create-unifiedgroupsource-withgroup-odata-bind-python-snippets.md
@@ -11,7 +11,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 request_body = UnifiedGroupSource(
 	included_sources = SourceType.Mailbox,
 	additional_data = {
-			"group@odata_bind" : "https://graph.microsoft.com/v1.0/groups/93f90172-fe05-43ea-83cf-ff785a40d610",
+			"group@odata.bind" : "https://graph.microsoft.com/v1.0/groups/93f90172-fe05-43ea-83cf-ff785a40d610",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/shared-channel-add-intra-tenant-member-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/shared-channel-add-intra-tenant-member-python-snippets.md
@@ -13,7 +13,7 @@ request_body = AadUserConversationMember(
 	roles = [
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users/24b3819b-4e1d-4f3e-86bd-e42b54d0b2b4",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users/24b3819b-4e1d-4f3e-86bd-e42b54d0b2b4",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/shared-channel-add-x-tenant-member-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/shared-channel-add-x-tenant-member-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 	],
 	tenant_id = "a18103d1-a6ef-4f66-ac64-e4ef42ea8681",
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/beta/users/bc3598dd-cce4-4742-ae15-173429951408",
+			"user@odata.bind" : "https://graph.microsoft.com/beta/users/bc3598dd-cce4-4742-ae15-173429951408",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/update-printershare-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/update-printershare-python-snippets.md
@@ -12,7 +12,7 @@ request_body = PrinterShare(
 	display_name = "ShareName",
 	allow_all_users = True,
 	additional_data = {
-			"printer@odata_bind" : "https://graph.microsoft.com/beta/print/printers/{id}",
+			"printer@odata.bind" : "https://graph.microsoft.com/beta/print/printers/{id}",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/update-simulation-from-draft-to-scheduled-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/update-simulation-from-draft-to-scheduled-python-snippets.md
@@ -31,7 +31,7 @@ request_body = Simulation(
 	),
 	additional_data = {
 			"@odata_etag" : "\"0100aa9b-0000-0100-0000-6396fa270000\"",
-			"payload@odata_bind" : "https://graph.microsoft.com/beta/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
+			"payload@odata.bind" : "https://graph.microsoft.com/beta/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/update-simulation-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/update-simulation-python-snippets.md
@@ -30,7 +30,7 @@ request_body = Simulation(
 	),
 	additional_data = {
 			"@odata_etag" : "\"0100aa9b-0000-0100-0000-6396fa270000\"",
-			"payload@odata_bind" : "https://graph.microsoft.com/beta/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
+			"payload@odata.bind" : "https://graph.microsoft.com/beta/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/user-add-teamsapp-consent-resource-specific-permissions-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/user-add-teamsapp-consent-resource-specific-permissions-python-snippets.md
@@ -18,7 +18,7 @@ request_body = UserScopeTeamsAppInstallation(
 		],
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/beta/includes/snippets/python/user-add-teamsapp-python-snippets.md
+++ b/api-reference/beta/includes/snippets/python/user-add-teamsapp-python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = UserScopeTeamsAppInstallation(
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/beta/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/add-app-in-chat-v1-e1-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/add-app-in-chat-v1-e1-python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = TeamsAppInstallation(
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/add-app-in-chat-v1-e2-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/add-app-in-chat-v1-e2-python-snippets.md
@@ -30,7 +30,7 @@ request_body = TeamsAppInstallation(
 		],
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/2b524e28-95ce-4c9b-9773-4a5bd6ec1770",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/2b524e28-95ce-4c9b-9773-4a5bd6ec1770",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/add-app-in-team-v1-e1-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/add-app-in-team-v1-e1-python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = TeamsAppInstallation(
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/add-app-in-team-v1-e2-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/add-app-in-team-v1-e2-python-snippets.md
@@ -22,7 +22,7 @@ request_body = TeamsAppInstallation(
 		],
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/7023576d-9e40-47ca-9cf2-daae6838e785",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/7023576d-9e40-47ca-9cf2-daae6838e785",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/add-multiple-members-to-group-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/add-multiple-members-to-group-python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = Group(
 	additional_data = {
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/directoryObjects/{id}",
 				"https://graph.microsoft.com/v1.0/directoryObjects/{id}",
 				"https://graph.microsoft.com/v1.0/directoryObjects/{id}",

--- a/api-reference/v1.0/includes/snippets/python/add-tab-to-chat-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/add-tab-to-chat-python-snippets.md
@@ -17,7 +17,7 @@ request_body = TeamsTab(
 		remove_url = "https://www.contoso.com/Orders/2DCA2E6C7A10415CAF6B8AB6661B3154/uninstallTab",
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/06805b9e-77e3-4b93-ac81-525eb87513b8",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/06805b9e-77e3-4b93-ac81-525eb87513b8",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/bulkaddmembers-team-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/bulkaddmembers-team-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AddPostRequestBody(
 			roles = [
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('18a80140-b0fb-4489-b360-2f6efaf225a0')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('18a80140-b0fb-4489-b360-2f6efaf225a0')",
 			}
 		),
 		AadUserConversationMember(
@@ -24,7 +24,7 @@ request_body = AddPostRequestBody(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('86503198-b81b-43fe-81ee-ad45b8848ac9')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('86503198-b81b-43fe-81ee-ad45b8848ac9')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/bulkaddmembers-team-upn-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/bulkaddmembers-team-upn-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AddPostRequestBody(
 			roles = [
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
 			}
 		),
 		AadUserConversationMember(
@@ -24,7 +24,7 @@ request_body = AddPostRequestBody(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('alex@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('alex@contoso.com')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/channel-add-member-1-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/channel-add-member-1-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/channel-add-member-2-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/channel-add-member-2-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/channel-add-member-3-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/channel-add-member-3-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/channel-add-member-6-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/channel-add-member-6-python-snippets.md
@@ -13,7 +13,7 @@ request_body = AadUserConversationMember(
 	roles = [
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/channelposttabs-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/channelposttabs-python-snippets.md
@@ -17,7 +17,7 @@ request_body = TeamsTab(
 		remove_url = "https://www.contoso.com/Orders/2DCA2E6C7A10415CAF6B8AB6661B3154/uninstallTab",
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/06805b9e-77e3-4b93-ac81-525eb87513b8",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/06805b9e-77e3-4b93-ac81-525eb87513b8",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/contenttype-post-conlumns-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/contenttype-post-conlumns-python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = ColumnDefinition(
 	additional_data = {
-			"source_column@odata_bind" : "https://graph.microsoft.com/v1.0/sites/root/columns/99ddcf45-e2f7-4f17-82b0-6fba34445103",
+			"source_column@odata.bind" : "https://graph.microsoft.com/v1.0/sites/root/columns/99ddcf45-e2f7-4f17-82b0-6fba34445103",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/convert-team-from-group-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/convert-team-from-group-python-snippets.md
@@ -29,18 +29,18 @@ request_body = Team(
 	installed_apps = [
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
 			}
 		),
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
-			"group@odata_bind" : "https://graph.microsoft.com/v1.0/groups('dbd8de4f-5d47-48da-87f1-594bed003375')",
+			"template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
+			"group@odata.bind" : "https://graph.microsoft.com/v1.0/groups('dbd8de4f-5d47-48da-87f1-594bed003375')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/convert-team-from-non-standard-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/convert-team-from-non-standard-python-snippets.md
@@ -12,7 +12,7 @@ request_body = Team(
 	display_name = "My Class Team",
 	description = "My Class Team’s Description",
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('educationClass')",
+			"template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('educationClass')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/convert-team-from-non-standard2-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/convert-team-from-non-standard2-python-snippets.md
@@ -31,17 +31,17 @@ request_body = Team(
 	installed_apps = [
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
 			}
 		),
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('educationClass')",
+			"template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('educationClass')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-channel-from-user-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-channel-from-user-python-snippets.md
@@ -20,7 +20,7 @@ request_body = Channel(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('62855810-484b-4823-9e01-60667f8b12ae')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('62855810-484b-4823-9e01-60667f8b12ae')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/create-chat-group-with-guest-user-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-chat-group-with-guest-user-python-snippets.md
@@ -18,7 +18,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')",
 			}
 		),
 		AadUserConversationMember(
@@ -27,7 +27,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')",
 			}
 		),
 		AadUserConversationMember(
@@ -36,7 +36,7 @@ request_body = Chat(
 				"guest",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/create-chat-group-with3-members-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-chat-group-with3-members-python-snippets.md
@@ -18,7 +18,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')",
 			}
 		),
 		AadUserConversationMember(
@@ -27,7 +27,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')",
 			}
 		),
 		AadUserConversationMember(
@@ -36,7 +36,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('3626a173-f2bc-4883-bcf7-01514c3bfb82')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('3626a173-f2bc-4883-bcf7-01514c3bfb82')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/create-chat-oneonone-e1-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-chat-oneonone-e1-python-snippets.md
@@ -17,7 +17,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 			}
 		),
 		AadUserConversationMember(
@@ -26,7 +26,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/create-chat-oneonone-federated-e5-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-chat-oneonone-federated-e5-python-snippets.md
@@ -17,7 +17,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 			}
 		),
 		AadUserConversationMember(
@@ -27,7 +27,7 @@ request_body = Chat(
 			],
 			tenant_id = "4dc1fe35-8ac6-4f0d-904a-7ebcd364bea1",
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/create-chat-oneonone-upn-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-chat-oneonone-upn-python-snippets.md
@@ -17,7 +17,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
 			}
 		),
 		AadUserConversationMember(
@@ -26,7 +26,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('alex@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('alex@contoso.com')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/create-conversation-member-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversation-member-python-snippets.md
@@ -13,7 +13,7 @@ request_body = AadUserConversationMember(
 	roles = [
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-conversation-member-upn-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversation-member-upn-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/jacob@contoso.com",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/jacob@contoso.com",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-all-visiblehistorystartdatetime-3-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-all-visiblehistorystartdatetime-3-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-2-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-2-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-5-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-5-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"guest",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-6-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-no-visiblehistorystartdatetime-6-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AadUserConversationMember(
 	],
 	tenant_id = "4dc1fe35-8ac6-4f0d-904a-7ebcd364bea1",
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/82af01c5-f7cc-4a2e-a728-3a5df21afd9d",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/82af01c5-f7cc-4a2e-a728-3a5df21afd9d",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-specific-visiblehistorystartdatetime-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversation-member-with-specific-visiblehistorystartdatetime-python-snippets.md
@@ -15,7 +15,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-conversationmember-from--python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversationmember-from--python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-conversationmember-upn-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-conversationmember-upn-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 		"owner",
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-ediscoveryreviewtag-with-a-parent-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-ediscoveryreviewtag-with-a-parent-python-snippets.md
@@ -13,7 +13,7 @@ request_body = EdiscoveryReviewTag(
 	description = "Use Graph API to create tags",
 	child_selectability = ChildSelectability.Many,
 	additional_data = {
-			"parent@odata_bind" : "",
+			"parent@odata.bind" : "",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-ediscoverysearch-from--python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-ediscoverysearch-from--python-snippets.md
@@ -13,12 +13,12 @@ request_body = EdiscoverySearch(
 	description = "My first search",
 	content_query = "(Author=\"edison\")",
 	additional_data = {
-			"custodian_sources@odata_bind" : [
+			"custodian_sources@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/b0073e4e-4184-41c6-9eb7-8c8cc3e2288b/custodians/0053a61a3b6c42738f7606791716a22a/userSources/43434642-3137-3138-3432-374142313639",
 				"https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/b0073e4e-4184-41c6-9eb7-8c8cc3e2288b/custodians/0053a61a3b6c42738f7606791716a22a/siteSources/169718e3-a8df-449d-bef4-ee09fe1ddc5d",
 				"https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases('b0073e4e-4184-41c6-9eb7-8c8cc3e2288b')/custodians('0053a61a3b6c42738f7606791716a22a')/unifiedGroupSources('32e14fa4-3106-4bd2-a245-34bf0c718a7e')",
 			],
-			"noncustodial_sources@odata_bind" : [
+			"noncustodial_sources@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/security/cases/ediscoveryCases/b0073e4e-4184-41c6-9eb7-8c8cc3e2288b/noncustodialdatasources/35393639323133394345384344303043",
 			],
 	}

--- a/api-reference/v1.0/includes/snippets/python/create-pinnedchatmessageinfo-from--python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-pinnedchatmessageinfo-from--python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = PinnedChatMessageInfo(
 	additional_data = {
-			"message@odata_bind" : "https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1616964509832",
+			"message@odata.bind" : "https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages/1616964509832",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-prepopulated-group-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-prepopulated-group-python-snippets.md
@@ -17,10 +17,10 @@ request_body = Group(
 	mail_nickname = "operations2019",
 	security_enabled = True,
 	additional_data = {
-			"owners@odata_bind" : [
+			"owners@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/26be1845-4119-4801-a799-aea79d09f1a2",
 			],
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/ff7cb387-6688-423c-8188-3da9532a73cc",
 				"https://graph.microsoft.com/v1.0/users/69456242-0067-49d3-ba96-9de6f2728e14",
 			],

--- a/api-reference/v1.0/includes/snippets/python/create-printershare-from--python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-printershare-from--python-snippets.md
@@ -12,7 +12,7 @@ request_body = PrinterShare(
 	display_name = "ShareName",
 	allow_all_users = False,
 	additional_data = {
-			"printer@odata_bind" : "https://graph.microsoft.com/v1.0/print/printers/{printerId}",
+			"printer@odata.bind" : "https://graph.microsoft.com/v1.0/print/printers/{printerId}",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-printtasktrigger-from--python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-printtasktrigger-from--python-snippets.md
@@ -11,7 +11,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 request_body = PrintTaskTrigger(
 	event = PrintEvent.JobStarted,
 	additional_data = {
-			"definition@odata_bind" : "https://graph.microsoft.com/v1.0/print/taskDefinitions/{taskDefinitionId}",
+			"definition@odata.bind" : "https://graph.microsoft.com/v1.0/print/taskDefinitions/{taskDefinitionId}",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-private-channel-upn-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-private-channel-upn-python-snippets.md
@@ -20,7 +20,7 @@ request_body = Channel(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/create-retentionevent-from--python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-retentionevent-from--python-snippets.md
@@ -19,7 +19,7 @@ request_body = RetentionEvent(
 						"@odata_type" : "microsoft.graph.security.eventQuery",
 				},
 			],
-			"retention_event_type@odata_bind" : "https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventType/9eecef97-fb3c-4c68-825b-4dd74530863a",
+			"retention_event_type@odata.bind" : "https://graph.microsoft.com/v1.0/security/triggerTypes/retentionEventType/9eecef97-fb3c-4c68-825b-4dd74530863a",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-role-enabled-group-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-role-enabled-group-python-snippets.md
@@ -19,10 +19,10 @@ request_body = Group(
 	security_enabled = True,
 	mail_nickname = "contosohelpdeskadministrators",
 	additional_data = {
-			"owners@odata_bind" : [
+			"owners@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/99e44b05-c10b-4e95-a523-e2732bbaba1e",
 			],
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/6ea91a8d-e32e-41a1-b7bd-d2d185eed0e0",
 				"https://graph.microsoft.com/v1.0/users/4562bcc8-c436-4f95-b7c0-4f8ce89dca5e",
 			],

--- a/api-reference/v1.0/includes/snippets/python/create-shared-channel-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-shared-channel-python-snippets.md
@@ -19,7 +19,7 @@ request_body = Channel(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('7640023f-fe43-573f-9ff4-84a9efe4acd6')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('7640023f-fe43-573f-9ff4-84a9efe4acd6')",
 			}
 		),
 	],

--- a/api-reference/v1.0/includes/snippets/python/create-simulations-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-simulations-python-snippets.md
@@ -37,15 +37,15 @@ request_body = Simulation(
 		additional_data = {
 				"simulation_notification" : {
 						"targetted_user_type" : "compromised",
-						"end_user_notification@odata_bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/endUserNotifications/12wer3678-9abc-def0-123456789a",
+						"end_user_notification@odata.bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/endUserNotifications/12wer3678-9abc-def0-123456789a",
 						"default_language" : "en",
 				},
 		}
 	),
 	additional_data = {
-			"payload@odata_bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
-			"login_page@odata_bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/loginPages/1w345678-9abc-def0-123456789a",
-			"landing_page@odata_bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/landingPages/1c345678-9abc-def0-123456789a",
+			"payload@odata.bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
+			"login_page@odata.bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/loginPages/1w345678-9abc-def0-123456789a",
+			"landing_page@odata.bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/landingPages/1c345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-team-from-group-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-team-from-group-python-snippets.md
@@ -10,8 +10,8 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = Team(
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
-			"group@odata_bind" : "https://graph.microsoft.com/v1.0/groups('71392b2f-1765-406e-86af-5907d9bdb2ab')",
+			"template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
+			"group@odata.bind" : "https://graph.microsoft.com/v1.0/groups('71392b2f-1765-406e-86af-5907d9bdb2ab')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-team-post-full-payload-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-team-post-full-payload-python-snippets.md
@@ -29,7 +29,7 @@ request_body = Team(
 						content_url = "https://learn.microsoft.com/microsoftteams/microsoft-teams",
 					),
 					additional_data = {
-							"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.web')",
+							"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.web')",
 					}
 				),
 				TeamsTab(
@@ -39,7 +39,7 @@ request_body = Team(
 						website_url = "https://www.youtube.com/watch?v=X8krAMdGvCQ",
 					),
 					additional_data = {
-							"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.youtube')",
+							"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.youtube')",
 					}
 				),
 			],
@@ -81,17 +81,17 @@ request_body = Team(
 	installed_apps = [
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('com.microsoft.teamspace.tab.vsts')",
 			}
 		),
 		TeamsAppInstallation(
 			additional_data = {
-					"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
+					"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps('1542629c-01b3-4a6d-8f76-1938b779e48d')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
 			"discovery_settings" : {
 					"show_in_teams_search_and_suggestions" : True,
 			},

--- a/api-reference/v1.0/includes/snippets/python/create-team-post-minimal-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-team-post-minimal-python-snippets.md
@@ -18,12 +18,12 @@ request_body = Team(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-team-post-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-team-post-python-snippets.md
@@ -12,7 +12,7 @@ request_body = Team(
 	display_name = "My Sample Team",
 	description = "My Sample Team’s Description",
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-team-post-upn-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-team-post-upn-python-snippets.md
@@ -18,12 +18,12 @@ request_body = Team(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')",
 			}
 		),
 	],
 	additional_data = {
-			"template@odata_bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
+			"template@odata.bind" : "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/create-unifiedgroupsource-with-groupodatabind-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-unifiedgroupsource-with-groupodatabind-python-snippets.md
@@ -11,7 +11,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 request_body = UnifiedGroupSource(
 	included_sources = SourceType.Mailbox,
 	additional_data = {
-			"group@odata_bind" : "https://graph.microsoft.com/v1.0/groups/93f90172-fe05-43ea-83cf-ff785a40d610",
+			"group@odata.bind" : "https://graph.microsoft.com/v1.0/groups/93f90172-fe05-43ea-83cf-ff785a40d610",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/shared-channel-add-intra-tenant-member-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/shared-channel-add-intra-tenant-member-python-snippets.md
@@ -13,7 +13,7 @@ request_body = AadUserConversationMember(
 	roles = [
 	],
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/24b3819b-4e1d-4f3e-86bd-e42b54d0b2b4",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/24b3819b-4e1d-4f3e-86bd-e42b54d0b2b4",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/shared-channel-add-x-tenant-member-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/shared-channel-add-x-tenant-member-python-snippets.md
@@ -14,7 +14,7 @@ request_body = AadUserConversationMember(
 	],
 	tenant_id = "a18103d1-a6ef-4f66-ac64-e4ef42ea8681",
 	additional_data = {
-			"user@odata_bind" : "https://graph.microsoft.com/v1.0/users/bc3598dd-cce4-4742-ae15-173429951408",
+			"user@odata.bind" : "https://graph.microsoft.com/v1.0/users/bc3598dd-cce4-4742-ae15-173429951408",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/update-printershare-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/update-printershare-python-snippets.md
@@ -12,7 +12,7 @@ request_body = PrinterShare(
 	display_name = "PrinterShare Name",
 	allow_all_users = False,
 	additional_data = {
-			"printer@odata_bind" : "https://graph.microsoft.com/v1.0/print/printers/{printerId}",
+			"printer@odata.bind" : "https://graph.microsoft.com/v1.0/print/printers/{printerId}",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/update-simulation-from-draft-to-scheduled-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/update-simulation-from-draft-to-scheduled-python-snippets.md
@@ -31,7 +31,7 @@ request_body = Simulation(
 	),
 	additional_data = {
 			"@odata_etag" : "\"0100aa9b-0000-0100-0000-6396fa270000\"",
-			"payload@odata_bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
+			"payload@odata.bind" : "https://graph.microsoft.com/v1.0/security/attacksimulation/payloads/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/user-add-teamsapp-consent-resource-specific-permissions-v1-e2-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/user-add-teamsapp-consent-resource-specific-permissions-v1-e2-python-snippets.md
@@ -18,7 +18,7 @@ request_body = UserScopeTeamsAppInstallation(
 		],
 	),
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/api-reference/v1.0/includes/snippets/python/user-add-teamsapp-v1-e1-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/user-add-teamsapp-v1-e1-python-snippets.md
@@ -10,7 +10,7 @@ graph_client = GraphServiceClient(credentials, scopes)
 
 request_body = UserScopeTeamsAppInstallation(
 	additional_data = {
-			"teams_app@odata_bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
+			"teams_app@odata.bind" : "https://graph.microsoft.com/v1.0/appCatalogs/teamsApps/12345678-9abc-def0-123456789a",
 	}
 )
 

--- a/includes/snippets/python/beta/tutorial-accessreviews-securitygroup-creategroup-python-snippets.md
+++ b/includes/snippets/python/beta/tutorial-accessreviews-securitygroup-creategroup-python-snippets.md
@@ -17,10 +17,10 @@ request_body = Group(
 	mail_nickname = "buildingsecurity",
 	security_enabled = True,
 	additional_data = {
-			"owners@odata_bind" : [
+			"owners@odata.bind" : [
 				"https://graph.microsoft.com/beta/users/d3bcdff4-4f80-4418-a65e-7bf3778c5dca",
 			],
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/beta/users/3b8ceebc-49e6-4e0c-9e14-c906374a7ef6",
 				"https://graph.microsoft.com/beta/users/bf59c5ba-5304-4c9b-9192-e5a4cb8444e7",
 			],

--- a/includes/snippets/python/v1/step-2-python-snippets.md
+++ b/includes/snippets/python/v1/step-2-python-snippets.md
@@ -17,7 +17,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('adams@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('adams@contoso.com')",
 			}
 		),
 		AadUserConversationMember(
@@ -26,7 +26,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('gradyA@contoso.com')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('gradyA@contoso.com')",
 			}
 		),
 		AadUserConversationMember(
@@ -35,7 +35,7 @@ request_body = Chat(
 				"owner",
 			],
 			additional_data = {
-					"user@odata_bind" : "https://graph.microsoft.com/v1.0/users('4562bcc8-c436-4f95-b7c0-4f8ce89dca5e')",
+					"user@odata.bind" : "https://graph.microsoft.com/v1.0/users('4562bcc8-c436-4f95-b7c0-4f8ce89dca5e')",
 			}
 		),
 	],

--- a/includes/snippets/python/v1/tutorial-accessreviews-m365group-creategroup-python-snippets.md
+++ b/includes/snippets/python/v1/tutorial-accessreviews-m365group-creategroup-python-snippets.md
@@ -18,10 +18,10 @@ request_body = Group(
 	mail_nickname = "FeelGoodCampaign",
 	security_enabled = True,
 	additional_data = {
-			"owners@odata_bind" : [
+			"owners@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/cdb555e3-b33e-4fd5-a427-17fadacbdfa7",
 			],
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/baf1b0a0-1f9a-4a56-9884-6a30824f8d20",
 			],
 	}

--- a/includes/snippets/python/v1/tutorial-assignaadroles-createsecuritygroup-python-snippets.md
+++ b/includes/snippets/python/v1/tutorial-assignaadroles-createsecuritygroup-python-snippets.md
@@ -16,10 +16,10 @@ request_body = Group(
 	security_enabled = True,
 	is_assignable_to_role = True,
 	additional_data = {
-			"owners@odata_bind" : [
+			"owners@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/1ed8ac56-4827-4733-8f80-86adc2e67db5",
 			],
-			"members@odata_bind" : [
+			"members@odata.bind" : [
 				"https://graph.microsoft.com/v1.0/users/1ed8ac56-4827-4733-8f80-86adc2e67db5",
 				"https://graph.microsoft.com/v1.0/users/7146daa8-1b4b-4a66-b2f7-cf593d03c8d2",
 			],


### PR DESCRIPTION
- Replacing the underscore in the odata bind annotation with a dot. 
- This leads to the expected behaviour, i.e. the group is created with an owner and members.