### PR TITLE
Update MEPM overview to link to permissions documentation

### DIFF
--- a/api-reference/beta/resources/permissions-management-api-overview.md
+++ b/api-reference/beta/resources/permissions-management-api-overview.md
@@ -98,13 +98,14 @@ Other findings include:
 
 ## Permissions and privileges
 
-To call the permissions management APIs, the caller doesn't need any Microsoft Graph permissions. However, they must have appropriate privileges in the Microsoft Entra tenant and also in the external system.
+To call the Permissions management APIs, the caller doesn't need any Microsoft Graph permissions. However, they must have appropriate permissions in the Microsoft Entra tenant and also in the external system.
 
-For more information, see [Quickstart guide to Microsoft Entra Permissions Management](/entra/permissions-management/permissions-management-quickstart-guide)
+For more information, see [Permissions Management roles and permissions levels](/entra/permissions-management/product-roles-permissions)
 
 ## See also
 
 - [What's Microsoft Entra Permissions Management](/entra/permissions-management/overview)
+- [Quickstart guide to Microsoft Entra Permissions Management](/entra/permissions-management/permissions-management-quickstart-guide)
 - [Microsoft Entra Permissions Management operations reference](/entra/architecture/permissions-manage-ops-guide-intro)
 - Microsoft Entra permissions management API operations quick references:
   - [For AWS authorization systems](/graph/permissions-management-how-to-authorization-system-aws)


### PR DESCRIPTION
Editing the Permissions section to link the MEPM roles and permissions docs page and moving the quickstart guide link under see also.