### PR TITLE
Update teamworktag-list-permissions.md

### DIFF
--- a/api-reference/v1.0/includes/permissions/teamworktag-list-permissions.md
+++ b/api-reference/v1.0/includes/permissions/teamworktag-list-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|TeamworkTag.ReadWrite|TeamworkTag.Read|
+|Delegated (work or school account)|TeamworkTag.Read|TeamworkTag.ReadWrite|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|TeamworkTag.ReadWrite.All|TeamworkTag.Read.All|
+|Application|TeamworkTag.Read.All|TeamworkTag.ReadWrite.All|
 


### PR DESCRIPTION
The least privileged and higher privileged permissions are the wrong way around.

**This file has a warning that it is automatically generated and should not be modified. Therefore, there might be a bug in how the file is generated which should be fixed rather than accepting this PR**