### PR TITLE
Update permissions-grant-via-msgraph.md

### DIFF
--- a/concepts/permissions-grant-via-msgraph.md
+++ b/concepts/permissions-grant-via-msgraph.md
@@ -32,7 +32,7 @@ To complete these instructions, you need the following resources and privileges:
 - You'll run the requests in this article as a user. You must complete the following steps:
     - Sign in to an app such as [Graph Explorer](https://developer.microsoft.com/graph/graph-explorer) or [Postman](/graph/use-postman) as a user with privileges to create applications in the tenant.
     - In the app you've signed in to, consent to the *Application.Read.All* and *AppRoleAssignment.ReadWrite.All* delegated permissions on behalf of the signed-in user. You don't need to consent on behalf of your organization.
-    - Get the object ID of the client service principal to which you'll grant app roles. In this article, the client service principal is identified by ID `b0d9b9e3-0ecf-4bfd-8dab-9273dd055a94`.
+    - Get the object ID of the client service principal to which you'll grant app roles. In this article, the client service principal is identified by ID `b0d9b9e3-0ecf-4bfd-8dab-9273dd055a94`. This information is exposed in the Enterprise Applications in the Azure Portal, find your Service Principal under All Applications.
 
 <!--
 > [!CAUTION]
@@ -136,11 +136,21 @@ Content-type: application/json
 
 ## Step 2: Grant an app role to a client service principal
 
-In this step, you'll grant your app an app role that's exposed by Microsoft Graph, thereby creating an **app role assignment**. From Step 1, the object ID of Microsoft Graph is `7ea9e944-71ce-443d-811c-71e8047b557a` and the app role `User.Read.All` is identified by ID `df021288-bdef-4463-88db-98f22de89214`.
+In this step, you'll grant your app an app role that's exposed by Microsoft Graph, thereby creating an **app role assignment**. From Step 1, the object ID of Microsoft Graph is `7ea9e944-71ce-443d-811c-71e8047b557a` and the app role `User.Read.All` is identified by ID `df021288-bdef-4463-88db-98f22de89214`. 
 
 ### Request
 
 The following request grants your client app (the principal of ID `b0d9b9e3-0ecf-4bfd-8dab-9273dd055a94`) an app role of ID `df021288-bdef-4463-88db-98f22de89214` that's exposed by a resource service principal of ID `7ea9e944-71ce-443d-811c-71e8047b557a`.
+
+> [!NOTE] 
+> If you are using Python you need to import the following libraries:
+> ```
+> from msgraph.generated.models.app_role_assignment import AppRoleAssignment
+> from msgraph.generated.models.service_principal import ServicePrincipal
+> ```
+
+> [!IMPORTANT]  
+> The Service Principal that will be used for the Credentials Authentication must have enough authority to be able to add or remove permissions.
 
 
 # [HTTP](#tab/http)

--- a/concepts/permissions-grant-via-msgraph.md
+++ b/concepts/permissions-grant-via-msgraph.md
@@ -32,7 +32,7 @@ To complete these instructions, you need the following resources and privileges:
 - You'll run the requests in this article as a user. You must complete the following steps:
     - Sign in to an app such as [Graph Explorer](https://developer.microsoft.com/graph/graph-explorer) or [Postman](/graph/use-postman) as a user with privileges to create applications in the tenant.
     - In the app you've signed in to, consent to the *Application.Read.All* and *AppRoleAssignment.ReadWrite.All* delegated permissions on behalf of the signed-in user. You don't need to consent on behalf of your organization.
-    - Get the object ID of the client service principal to which you'll grant app roles. In this article, the client service principal is identified by ID `b0d9b9e3-0ecf-4bfd-8dab-9273dd055a94`. In the Microsoft Entra admin center, navigate to **Identity** > expand **Applications** > select **Enterprise applications** > select **App applications** tab and find the client service principal. Select it and on the **Overview** page, copy the Object ID value.
+    - Get the object ID of the client service principal to which you'll grant app roles. In this article, the client service principal is identified by ID `b0d9b9e3-0ecf-4bfd-8dab-9273dd055a94`. In the Microsoft Entra admin center, go to **Identity** > **Applications** > **Enterprise applications** > **App applications** to find the client service principal. Select it and on the **Overview** page, copy the Object ID value.
 
 <!--
 > [!CAUTION]

--- a/concepts/permissions-grant-via-msgraph.md
+++ b/concepts/permissions-grant-via-msgraph.md
@@ -32,7 +32,7 @@ To complete these instructions, you need the following resources and privileges:
 - You'll run the requests in this article as a user. You must complete the following steps:
     - Sign in to an app such as [Graph Explorer](https://developer.microsoft.com/graph/graph-explorer) or [Postman](/graph/use-postman) as a user with privileges to create applications in the tenant.
     - In the app you've signed in to, consent to the *Application.Read.All* and *AppRoleAssignment.ReadWrite.All* delegated permissions on behalf of the signed-in user. You don't need to consent on behalf of your organization.
-    - Get the object ID of the client service principal to which you'll grant app roles. In this article, the client service principal is identified by ID `b0d9b9e3-0ecf-4bfd-8dab-9273dd055a94`. This information is exposed in the Enterprise Applications in the Azure Portal, find your Service Principal under All Applications.
+    - Get the object ID of the client service principal to which you'll grant app roles. In this article, the client service principal is identified by ID `b0d9b9e3-0ecf-4bfd-8dab-9273dd055a94`. In the Microsoft Entra admin center, navigate to **Identity** > expand **Applications** > select **Enterprise applications** > select **App applications** tab and find the client service principal. Select it and on the **Overview** page, copy the Object ID value.
 
 <!--
 > [!CAUTION]
@@ -143,15 +143,11 @@ In this step, you'll grant your app an app role that's exposed by Microsoft Grap
 The following request grants your client app (the principal of ID `b0d9b9e3-0ecf-4bfd-8dab-9273dd055a94`) an app role of ID `df021288-bdef-4463-88db-98f22de89214` that's exposed by a resource service principal of ID `7ea9e944-71ce-443d-811c-71e8047b557a`.
 
 > [!NOTE] 
-> If you are using Python you need to import the following libraries:
+> If you're using the Python SDK, import the following libraries:
 > ```
 > from msgraph.generated.models.app_role_assignment import AppRoleAssignment
 > from msgraph.generated.models.service_principal import ServicePrincipal
 > ```
-
-> [!IMPORTANT]  
-> The Service Principal that will be used for the Credentials Authentication must have enough authority to be able to add or remove permissions.
-
 
 # [HTTP](#tab/http)
 <!-- {


### PR DESCRIPTION
You will be able to see the new permission at the Enterprise Applications - PermissionsTab Under the App registration it will be Other Permissions add at the end of the list for API permissions tab. In order to move that permission and activate you need to Grant Admin Consent.



I was following this guide for python and I found a little bit challenge. So adding the things I believe it would make it more clear 1) The object ID for the SP is to be taken from Enterprise Applications.

2) The user that will pass the credentials to alter the SP must have high permissions to do it so. I was able to do that with one SP added as global administrator and that one given permissions to a second SP. 3) Which libraries for python to be able to use the sample code.

This was my personal step by step:

1 Replace the information client_ID and Client_secret with the SP with high permissions. This first step will represent the credential that must have enough permissions for the next step.


tenant_id = "Replace with Tenant ID"
client_id = "Replace with Service Principal ID that has high permissions" client_secret = "Replace with secret from the SP that has high permissions" 

6.2 The next step you will replace with the Service Principal that you will change the permissions. For example adding those 2 permissions. You will use the Object ID as Client_ID that you got from the Enterprise Applications: •	User.Read.All
•	User.ReadWrite.All 
In the code context:
•	Resource ID is the Microsoft Graph ID that
•	Client_ID is the Object ID from Enterprise Application •	App Role id is the ID of the role that you want to change