### PR TITLE
Fix typo in remoteItem.md

### DIFF
--- a/api-reference/beta/resources/remoteitem.md
+++ b/api-reference/beta/resources/remoteitem.md
@@ -17,7 +17,7 @@ Namespace: microsoft.graph
 The **remoteItem** resource indicates that a [**driveItem**](driveitem.md) references an item that exists in another drive.
 This resource provides the unique IDs of the source drive and target item.
 
-[**DriveItems**](driveitem.md) with a non-null **remoteItem** facet are resources that are shared, added to the user's OneDrive, or on items returned from hetrogenous collections of items (like search results).
+[**DriveItems**](driveitem.md) with a non-null **remoteItem** facet are resources that are shared, added to the user's OneDrive, or on items returned from heterogenous collections of items (like search results).
 
 **Note:** Unlike with folders in the same drive, a **driveItem** moved into a remote item may have its `id` value changed.
 

--- a/api-reference/v1.0/resources/remoteitem.md
+++ b/api-reference/v1.0/resources/remoteitem.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph
 The **remoteItem** resource indicates that a [**driveItem**](driveitem.md) references an item that exists in another drive.
 This resource provides the unique IDs of the source drive and target item.
 
-[**driveItems**](driveitem.md) with a non-null **remoteItem** facet are resources that are shared, added to the user's OneDrive, or on items returned from hetrogenous collections of items (like search results).
+[**driveItems**](driveitem.md) with a non-null **remoteItem** facet are resources that are shared, added to the user's OneDrive, or on items returned from heterogeneous collections of items (like search results).
 
 >**Note:** Unlike with folders in the same drive, a **driveItem** moved into a remote item may have its `id` value changed.
 


### PR DESCRIPTION
Fixes spelling of `heterogenous` in `remoteitem.md` for both `beta` and `v1.0`