### PR TITLE
Updated setting extension property to null using (string) null

### DIFF
--- a/includes/snippets/csharp/beta/extensibility-overview-schemaextensions-update-users-csharp-snippets.md
+++ b/includes/snippets/csharp/beta/extensibility-overview-schemaextensions-update-users-csharp-snippets.md
@@ -17,7 +17,7 @@ var requestBody = new User
 			"extkmpdyld2_graphLearnCourses" , new 
 			{
 				CourseType = "Instructor-led",
-				CourseId = null,
+				CourseId = (string) null,
 			}
 		},
 	},


### PR DESCRIPTION
The code "CourseId = null" currently returns the following error: Cannot assign '<null>' to anonymous type 

Modifying the code to "CourseId = (string) null" resolves this error.