### PR TITLE
Update message-createforward-csharp-snippets.md to fix issue

### DIFF
--- a/api-reference/v1.0/includes/snippets/csharp/message-createforward-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/message-createforward-csharp-snippets.md
@@ -7,7 +7,7 @@ description: "Automatically generated file. DO NOT MODIFY"
 // Code snippets are only available for the latest version. Current version is 5.x
 
 // To initialize your graphClient, see https://learn.microsoft.com/en-us/graph/sdks/create-client?from=snippets&tabs=csharp
-var result = await graphClient.Me.Messages["{message-id}"].CreateForward.PostAsync(null);
+var result = await graphClient.Me.Messages["{message-id}"].CreateForward.PostAsync(new CreateForwardPostRequestBody());
 
 
 ```


### PR DESCRIPTION
The `PostAsync` command requires a parameter. `null` is not a valid parameter and raises an exception.