### PR TITLE
Include `$` character for consistency with SDK generation.

### DIFF
--- a/api-reference/v1.0/api/listitem-list.md
+++ b/api-reference/v1.0/api/listitem-list.md
@@ -57,7 +57,7 @@ The following is an example of a request.
 <!-- { "blockType": "request", "name": "get-list-items", "scopes": "sites.read.all" } -->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/sites/{site-id}/lists/{list-id}/items?expand=fields(select=Name,Color,Quantity)
+GET https://graph.microsoft.com/v1.0/sites/{site-id}/lists/{list-id}/items?$expand=fields($select=Name,Color,Quantity)
 ```
 
 # [C#](#tab/csharp)


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1881

Sdks generate paths with `$` characters which are still valid. 