### PR TITLE
Update insights-customize-item-insights-privacy.md

### DIFF
--- a/concepts/insights-customize-item-insights-privacy.md
+++ b/concepts/insights-customize-item-insights-privacy.md
@@ -115,7 +115,6 @@ Use the [update](/graph/api/insightssettings-update?view=graph-rest-beta&preserv
 Keep the following in mind when updating item insights settings:
 - [insights settings](/graph/api/resources/insightssettings?view=graph-rest-beta&preserve-view=true) are available only in the beta endpoint.
 - Get the ID of a Microsoft Entra group from the Microsoft Entra admin center, and make sure the group exists, because the update operation does not check the existence of the group. Specifying a non-existent group in **disabledForGroup** does _not_ disable insights for any users in the organization.
-- Updating settings can take up to 24 hours to be applied across all Microsoft 365 experiences.
 - Regardless of item insights settings, Delve continues to respect Delve tenant and user level [privacy settings](/sharepoint/delve-for-office-365-admins#control-access-to-delve-and-related-features?view=graph-rest-beta&preserve-view=true).
 
 


### PR DESCRIPTION
The reason for this change? We have evidence from an ongoing investigation/critsit with Charter that 24 hours is simply wrong. We are current at 72 hours and no hope in sight. 
 
We believe that the time to update insights setting is based on the size of the body of content within the entire tenant… but I can’t think of a good way to convert that into a number of hours. Better to simply delete that line from the documentation in my opinion.