### PR TITLE
Fix incorrect link in authenticationmethodconfiguration.md

### DIFF
--- a/api-reference/beta/resources/authenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/authenticationmethodconfiguration.md
@@ -22,7 +22,7 @@ The following authentication methods are derived from the **authenticationMethod
 + [microsoftAuthenticatorAuthenticationMethodConfiguration](microsoftauthenticatorauthenticationmethodconfiguration.md)
 + [smsAuthenticationMethodConfiguration](smsauthenticationmethodconfiguration.md)
 + [softwareOathAuthenticationMethodConfiguration](softwareoathauthenticationmethodconfiguration.md)
-+ [temporaryAccessPassAuthenticationMethodConfiguration](smsauthenticationmethodconfiguration.md)
++ [temporaryAccessPassAuthenticationMethodConfiguration](temporaryaccesspassauthenticationmethodconfiguration.md)
 + [voiceAuthenticationMethodConfiguration](voiceauthenticationmethodconfiguration.md)
 + [x509CertificateAuthenticationMethodConfiguration](x509certificateauthenticationmethodconfiguration.md)
 

--- a/api-reference/v1.0/resources/authenticationmethodconfiguration.md
+++ b/api-reference/v1.0/resources/authenticationmethodconfiguration.md
@@ -20,7 +20,7 @@ The following authentication methods are derived from the **authenticationMethod
 + [voiceAuthenticationMethodConfiguration](voiceauthenticationmethodconfiguration.md)
 + [smsAuthenticationMethodConfiguration](smsauthenticationmethodconfiguration.md)
 + [softwareOathAuthenticationMethodConfiguration](softwareoathauthenticationmethodconfiguration.md)
-+ [temporaryAccessPassAuthenticationMethodConfiguration](smsauthenticationmethodconfiguration.md)
++ [temporaryAccessPassAuthenticationMethodConfiguration](temporaryaccesspassauthenticationmethodconfiguration.md)
 + [x509CertificateAuthenticationMethodConfiguration](x509certificateauthenticationmethodconfiguration.md)
 
 ## Properties


### PR DESCRIPTION
Looks like an incorrect copy and paste of the content above:
```
+ [smsAuthenticationMethodConfiguration](smsauthenticationmethodconfiguration.md)
```