### PR TITLE
Fix empty request body

### DIFF
--- a/api-reference/beta/api/educationassignment-setupfeedbackresourcesfolder.md
+++ b/api-reference/beta/api/educationassignment-setupfeedbackresourcesfolder.md
@@ -58,10 +58,6 @@ The following is an example of a request.
 }-->
 ```http
 POST https://graph.microsoft.com/beta/education/classes/37d99af7-cfc5-4e3b-8566-f7d40e4a2070/assignments/a3cce0ba-2008-4c4d-bf62-079408562d96/setUpFeedbackResourcesFolder
-Content-type: application/json
-
-{
-}
 ```
 
 # [C#](#tab/csharp)


### PR DESCRIPTION
Endpoint does not expect body according to metadata causing incorrect snippets to be generated.