### PR TITLE
connectorgroup.md: add possible value

### DIFF
--- a/api-reference/beta/resources/connectorgroup.md
+++ b/api-reference/beta/resources/connectorgroup.md
@@ -34,7 +34,7 @@ After a connector group is created, you can add or move connectors to the connec
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|connectorGroupType|connectorGroupType| Indicates the type of hybrid agent. This pre-set by the system. Possible values are: `applicationProxy`. Read-only. |
+|connectorGroupType|connectorGroupType| Indicates the type of hybrid agent. This pre-set by the system. Possible values are: `applicationProxy`, `syncFabric`. Read-only. |
 |id|string| Unique identifier for this connectorGroup. Read-only. |
 |isDefault|boolean| Indicates if the connectorGroup is the default connectorGroup. Only a single connector group can be the default connectorGroup and this is pre-set by the system. Read-only. |
 |name|string| The name associated with the connectorGroup. |


### PR DESCRIPTION
Observed in an API response in a real env


```
{
    "@odata.context": "https://graph.microsoft.com/beta/$metadata#onPremisesPublishingProfiles('applicationProxy')/connectorGroups",
    "value": [
        {
            "id": "a1ab5519-<redacted>",
            "name": "Default",
            "region": "eur",
            "connectorGroupType": "applicationProxy",
            "isDefault": true
        },
        {
            "id": "5e725447-<redacted>",
            "name": "Group-<redacted>-a18a3741-<redacted>",
            "region": "eur",
            "connectorGroupType": "syncFabric",
            "isDefault": false
        },
        {
            "id": "3f35a33e-<redacted>",
            "name": "Default group for AD Sync Fabric",
            "region": "eur",
            "connectorGroupType": "syncFabric",
            "isDefault": false
        }
    ]
}
```