### PR TITLE
PowerShell references: Add Azure AD and MSOnline PowerShell deprecation note

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -100,7 +100,14 @@
       "url": "https://github.com/MicrosoftDocs/azure-reference-other",
       "branch": "main",
       "branch_mapping": {}
+    },
+    {
+      "path_to_root": "api-reference/reusable-content",
+      "url": "https://github.com/MicrosoftDocs/reusable-content",
+      "branch": "main",
+      "branch_mapping": {}
     }
+    
   ],
   "branch_target_mapping": {},
   "targets": {},

--- a/api-reference/v1.0/resources/authenticationmethods-overview.md
+++ b/api-reference/v1.0/resources/authenticationmethods-overview.md
@@ -2,7 +2,7 @@
 title: "Microsoft Entra authentication methods API overview"
 description: "Authentication methods are how users authenticate in Azure AD."
 ms.localizationpriority: medium
-ms.custom: has-azure-ad-ps-ref
+ms.custom: has-azure-ad-ps-ref, azure-ad-ref-level-one-done
 author: "jpettere"
 ms.reviewer: intelligentaccesspm
 ms.subservice: "entra-sign-in"
@@ -49,6 +49,8 @@ The following authentication methods are not yet supported in Microsoft Graph v1
 |Default method | Represents the method the user has selected as default for performing multi-factor authentication.| Change a user's default MFA method. <br/> **NOTE:** Managing the details of the default method is currently supported only through the MSOL `Get-MsolUser` and `Set-MsolUser` cmdlets, using the **StrongAuthenticationMethods** property. |
 |Hardware token | Allow users to perform multifactor authentication using a physical device that provides a one-time code. | Get a hardware token assigned to a user.|
 |Security questions and answers | Allow users to validate their identity when performing a self-service password reset. |Delete a security question a user registered.|
+
+[!INCLUDE [Azure AD PowerShell deprecation note](~/../api-reference/reusable-content/msgraph-powershell/includes/aad-powershell-deprecation-note.md)]
 
 ## Require re-register multifactor authentication
 

--- a/concepts/auth-cloudsolutionprovider.md
+++ b/concepts/auth-cloudsolutionprovider.md
@@ -4,7 +4,7 @@ description: "This article describes how to enable application access to partner
 author: koravvams
 ms.localizationpriority: high
 ms.subservice: "partner-customer-administration"
-ms.custom: graphiamtop20, has-azure-ad-ps-ref
+ms.custom: graphiamtop20, has-azure-ad-ps-ref, azure-ad-ref-level-one-done
 ---
 
 # Call Microsoft Graph from a Cloud Solution Provider application
@@ -39,6 +39,8 @@ The initial steps required here follow most of the same steps used to register a
 ### Preconsent your app for all your customers
 
 Finally grant your partner-managed app those configured permissions for all your customers. You can do this by adding the **servicePrincipal** that represents the app to the *Adminagents* group in your Partner tenant, using [Azure AD PowerShell V2](https://www.powershellgallery.com/packages/AzureAD) or [Microsoft Graph PowerShell](/powershell/microsoftgraph/installation). Follow these steps to find the *Adminagents* group, the **servicePrincipal** and add it to the group.
+
+[!INCLUDE [Azure AD PowerShell deprecation note](~/../api-reference/reusable-content/msgraph-powershell/includes/aad-powershell-deprecation-note.md)]
 
 # [Azure AD PowerShell](#tab/azuread)
 


### PR DESCRIPTION
This PR updates 2 files with the deprecation note approved by @CelesteDG.

This update adds a note to address instances of Azure AD and MSOnline PowerShell in content.

ADO reference:

- 155267
- 155269