### PR TITLE
working elsewhere is been identified as 0 not 4!

### DIFF
--- a/api-reference/v1.0/resources/scheduleinformation.md
+++ b/api-reference/v1.0/resources/scheduleinformation.md
@@ -16,7 +16,7 @@ Represents the availability of a user, distribution list, or resource (room or e
 ## Properties
 | Property       | Type    |Description|
 |:---------------|:--------|:----------|
-|availabilityView |String |Represents a merged view of availability of all the items in `scheduleItems`. The view consists of time slots. Availability during each time slot is indicated with: `0`= free, `1`= tentative, `2`= busy, `3`= out of office, `4`= working elsewhere.|
+|availabilityView |String |Represents a merged view of availability of all the items in `scheduleItems`. The view consists of time slots. Availability during each time slot is indicated with: `0`= free, `1`= tentative, `2`= busy, `3`= out of office, `0`= working elsewhere.|
 |error |[freeBusyError](freebusyerror.md) |Error information from attempting to get the availability of the user, distribution list, or resource. |
 |scheduleId |String |An SMTP address of the user, distribution list, or resource, identifying an instance of **scheduleInformation**. |
 |scheduleItems |[scheduleItem](scheduleitem.md) collection |Contains the items that describe the availability of the user or resource. |


### PR DESCRIPTION
I do not know, whether it is intentionally or a bug, but if one requests getschedule an appointmeint "shownAs" as "working elsewhere" is represented with a zero, not 4.