### PR TITLE
Update user-list-memberof.md

### DIFF
--- a/api-reference/beta/api/user-list-memberof.md
+++ b/api-reference/beta/api/user-list-memberof.md
@@ -27,6 +27,10 @@ Choose the permission or permissions marked as least privileged for this API. Us
 
 [!INCLUDE [limited-info](../../includes/limited-info.md)]
 
+> [!TIP]
+> - Calling the `/me/memberOf` endpoint requires a signed-in user and therefore a delegated permission. Application permissions are not supported when you use the `/me/memberOf` endpoint.
+> - To list the members of a group with hidden membership, the `Member.Read.Hidden` permission is required.
+
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/user-list-memberof.md
+++ b/api-reference/v1.0/api/user-list-memberof.md
@@ -23,7 +23,9 @@ Choose the permission or permissions marked as least privileged for this API. Us
 <!-- { "blockType": "permissions", "name": "user_list_memberof" } -->
 [!INCLUDE [permissions-table](../includes/permissions/user-list-memberof-permissions.md)]
 
-> **Note:** To list the members of a group with hidden membership, the Member.Read.Hidden permission is required.
+> [!TIP]
+> 1. Calling the `/me/memberOf` endpoint requires a signed-in user and therefore a delegated permission. Application permissions are not supported when using the `/me/memberOf` endpoint.
+> 2. To list the members of a group with hidden membership, the Member.Read.Hidden permission is required.
 
 [!INCLUDE [limited-info](../../includes/limited-info.md)]
 

--- a/api-reference/v1.0/api/user-list-memberof.md
+++ b/api-reference/v1.0/api/user-list-memberof.md
@@ -24,8 +24,8 @@ Choose the permission or permissions marked as least privileged for this API. Us
 [!INCLUDE [permissions-table](../includes/permissions/user-list-memberof-permissions.md)]
 
 > [!TIP]
-> 1. Calling the `/me/memberOf` endpoint requires a signed-in user and therefore a delegated permission. Application permissions are not supported when using the `/me/memberOf` endpoint.
-> 2. To list the members of a group with hidden membership, the Member.Read.Hidden permission is required.
+> - Calling the `/me/memberOf` endpoint requires a signed-in user and therefore a delegated permission. Application permissions are not supported when you use the `/me/memberOf` endpoint.
+> - To list the members of a group with hidden membership, the `Member.Read.Hidden` permission is required.
 
 [!INCLUDE [limited-info](../../includes/limited-info.md)]
 


### PR DESCRIPTION
Clarify that Application permission is supported for "GET /users/{id | userPrincipalName}/memberOf" request but doesn't work for "GET /me/memberOf". Current permission information is misleading that Application permission is not supported.