### PR TITLE
Use correct argument for Get-Content to return bytes

### DIFF
--- a/concepts/applications-how-to-add-certificate.md
+++ b/concepts/applications-how-to-add-certificate.md
@@ -64,7 +64,7 @@ To read the certificate's key using PowerShell, run the following request.
 ```powershell-interactive
 ## Replace the file path with the location of your certificate
 
-[convert]::ToBase64String((Get-Content C:\Users\admin\Desktop\20230112.cer -Encoding byte))  | Out-File -FilePath "C:\Users\admin\Desktop\20230112.key.txt"
+[convert]::ToBase64String((Get-Content C:\Users\admin\Desktop\20230112.cer -AsByteStream))  | Out-File -FilePath "C:\Users\admin\Desktop\20230112.key.txt"
 ```
 
 #### Response

--- a/concepts/applications-how-to-add-certificate.md
+++ b/concepts/applications-how-to-add-certificate.md
@@ -61,6 +61,16 @@ To read the certificate's key using PowerShell, run the following request.
 
 #### Request
 
+**PowerShell < 6**:
+
+```powershell-interactive
+## Replace the file path with the location of your certificate
+
+[convert]::ToBase64String((Get-Content C:\Users\admin\Desktop\20230112.cer -Encoding byte)) | Out-File -FilePath "C:\Users\admin\Desktop\20230112.key.txt"
+```
+
+**PowerShell >= 6**:
+
 ```powershell-interactive
 ## Replace the file path with the location of your certificate
 


### PR DESCRIPTION
The correct way to return bytes from Get-Content is to use the parameter `-AsByteStream`, rather than `-Encoding bytes`.

 https://learn.microsoft.com/en-gb/powershell/module/microsoft.powershell.management/get-content?view=powershell-7.4#parameters