### PR TITLE
Update TrustFrameworkKeySet Policy Keys Document for keys_v2

### DIFF
--- a/api-reference/beta/api/trustframeworkkeyset-getkey.md
+++ b/api-reference/beta/api/trustframeworkkeyset-getkey.md
@@ -1,0 +1,100 @@
+---
+title: "trustFrameworkKeySet: get key"
+description: "Get the key from the keyset."
+ms.localizationpriority: medium
+author: "gyanendersinghgithub"
+ms.subservice: "entra-sign-in"
+doc_type: "apiPageType"
+---
+
+# Get key from trustFrameworkKeySet
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Get the [trustFrameworkKey_v2](../resources/trustframeworkkey_v2.md) from a [trustFrameworkKeySet](../resources/trustframeworkkeyset.md).
+
+## Permissions
+
+Choose the permission or permissions marked as least privileged for this API. Use a higher privileged permission or permissions [only if your app requires it](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions). For details about delegated and application permissions, see [Permission types](/graph/permissions-overview#permission-types). To learn more about these permissions, see the [permissions reference](/graph/permissions-reference).
+
+<!-- { "blockType": "permissions", "name": "trustframeworkkeyset_getkey" } -->
+[!INCLUDE [permissions-table](../includes/permissions/trustframeworkkeyset-getkey-permissions.md)]
+
+## HTTP request
+
+<!-- { "blockType": "ignored" } -->
+
+```http
+GET /trustFramework/keySets/{id}/keys_v2/{keyId}
+```
+
+## Request headers
+
+| Name          | Description   |
+|:--------------|:--------------|
+|Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
+
+## Request body
+
+Don't supply a request body for this method.
+
+## Response
+
+If successful, this method returns a `200 OK` response code and a new [trustFrameworkKey_v2](../resources/trustframeworkkey_v2.md) object in the response body.
+
+## Examples
+
+### Request
+
+The following example shows a request.
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "trustframeworkkeyset_getkey"
+}-->
+
+```http
+GET https://graph.microsoft.com/beta/trustFramework/keySets/{id}/keys_v2/{keyId}
+```
+
+### Response
+
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
+
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.trustFrameworkKey_v2"
+} -->
+
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+
+{
+  "k": "k-value",
+  "x5c": [
+    "x5c-value"
+  ],
+  "x5t": "x5t-value",
+  "kty": "kty-value",
+  "use": "use-value",
+  "exp": 99,
+  "status": "enabled"
+}
+```
+
+<!-- uuid: 16cd6b66-4b1a-43a1-adaf-3a886856ed98
+2024-04-10 14:57:30 UTC -->
+<!-- {
+  "type": "#page.annotation",
+  "description": "trustFrameworkKeySet: getKey",
+  "keywords": "",
+  "section": "documentation",
+  "tocPath": ""
+}-->

--- a/api-reference/beta/api/trustframeworkkeyset-patchkeystatus.md
+++ b/api-reference/beta/api/trustframeworkkeyset-patchkeystatus.md
@@ -1,0 +1,96 @@
+---
+title: "trustFrameworkKey: Patch key status"
+description: "Patch key status for a key in a **trustFrameworkKeySet** object."
+ms.localizationpriority: medium
+author: "Nickgmicrosoft"
+ms.subservice: "entra-sign-in"
+doc_type: "apiPageType"
+---
+
+# Patch trustFrameworkKey status
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Patch key status for a key in a [trustFrameworkKeySet](../resources/trustframeworkkeyset.md). The operation will update the status for the targeted key within the container. Target Keyset container id will be passed in the url.
+
+## Permissions
+
+Choose the permission or permissions marked as least privileged for this API. Use a higher privileged permission or permissions [only if your app requires it](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions). For details about delegated and application permissions, see [Permission types](/graph/permissions-overview#permission-types). To learn more about these permissions, see the [permissions reference](/graph/permissions-reference).
+
+<!-- { "blockType": "permissions", "name": "trustframeworkkeyset_patchkeystatus" } -->
+[!INCLUDE [permissions-table](../includes/permissions/trustframeworkkeyset-patchkeystatus-permissions.md)]
+
+## HTTP request
+
+<!-- { "blockType": "ignored" } -->
+
+```http
+PATCH /trustFramework/keySets/{id}/keys_v2/{keyId}
+```
+
+## Request headers
+
+| Name          | Description   |
+|:--------------|:--------------|
+|Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
+| Content-type  | application/json. Required. |
+
+## Request body
+
+In the request body, provide a JSON object with the following parameters.
+
+| Parameter    | Type        | Description |
+|:-------------|:------------|:------------|
+|status|String|Similar to the **status** property of **trustFrameworkKey_v2**.|
+
+## Response
+
+If successful, this method returns a `204 No Content` response code.
+
+## Examples
+
+### Request
+
+The following example shows a request.
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "trustframeworkkeyset_patchKeyStatus"
+}-->
+
+```http
+PATCH https://graph.microsoft.com/beta/trustFramework/keySets/{id}/keys_v2/{keyId}
+Content-type: application/json
+{
+    "status": "disabled"
+}
+```
+
+### Response
+
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
+
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.trustFrameworkKey_v2"
+} -->
+
+```http
+HTTP/1.1 204  No Content
+Content-type: application/json
+
+<!-- uuid: 16cd6b66-4b1a-43a1-adaf-3a886856ed98
+2024-04-10 14:57:30 UTC -->
+<!-- {
+  "type": "#page.annotation",
+  "description": "trustFrameworkKeySet: patchKeyStatus",
+  "keywords": "",
+  "section": "documentation",
+  "tocPath": ""
+}-->

--- a/api-reference/beta/api/trustframeworkkeyset-patchkeystatus.md
+++ b/api-reference/beta/api/trustframeworkkeyset-patchkeystatus.md
@@ -84,6 +84,7 @@ The following example shows the response.
 ```http
 HTTP/1.1 204  No Content
 Content-type: application/json
+```
 
 <!-- uuid: 16cd6b66-4b1a-43a1-adaf-3a886856ed98
 2024-04-10 14:57:30 UTC -->

--- a/api-reference/beta/includes/permissions/trustframeworkkeyset-getkey-permissions.md
+++ b/api-reference/beta/includes/permissions/trustframeworkkeyset-getkey-permissions.md
@@ -1,0 +1,12 @@
+---
+description: "Automatically generated file. DO NOT MODIFY"
+ms.topic: include
+ms.localizationpriority: medium
+---
+
+|Permission type|Least privileged permissions|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|TrustFrameworkKeySet.Read.All|TrustFrameworkKeySet.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|TrustFrameworkKeySet.Read.All|TrustFrameworkKeySet.ReadWrite.All|
+

--- a/api-reference/beta/includes/permissions/trustframeworkkeyset-patchkeystatus-permissions.md
+++ b/api-reference/beta/includes/permissions/trustframeworkkeyset-patchkeystatus-permissions.md
@@ -1,0 +1,12 @@
+---
+description: "Automatically generated file. DO NOT MODIFY"
+ms.topic: include
+ms.localizationpriority: medium
+---
+
+|Permission type|Least privileged permissions|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|TrustFrameworkKeySet.ReadWrite.All|Not available.|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|TrustFrameworkKeySet.ReadWrite.All|Not available.|
+

--- a/api-reference/beta/resources/trustFrameworkkey_v2.md
+++ b/api-reference/beta/resources/trustFrameworkkey_v2.md
@@ -1,19 +1,28 @@
 ---
-title: "trustFrameworkKey resource type"
-description: "Represents a JWK (JSON Web Key). TrustFrameworkKey is a JSON data structure that represents a cryptographic key. The structure of this resource follows the format defined in RFC 7517 Section 4."
+title: "trustFrameworkKey_v2 resource type"
+description: "Represents a JWK (JSON Web Key). TrustFrameworkKey_v2 is a JSON data structure that represents a cryptographic key. The structure of this resource follows the format defined in RFC 7517 Section 4."
 ms.localizationpriority: medium
 author: "valnav"
 ms.subservice: "entra-sign-in"
 doc_type: "resourcePageType"
 ---
 
-# trustFrameworkKey resource type
+# trustFrameworkKey_v2 resource type
 
 Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents a JWK (JSON Web Key). TrustFrameworkKey is a JSON data structure that represents a cryptographic key. The structure of this resource follows the format defined in [RFC 7517 Section 4](https://tools.ietf.org/html/rfc7517#section-4).
+Represents a JWK (JSON Web Key). TrustFrameworkKey_v2 is a JSON data structure that represents a cryptographic key. The structure of this resource follows the format defined in [RFC 7517 Section 4](https://tools.ietf.org/html/rfc7517#section-4).
+
+## Methods
+
+| Method       | Return Type | Description |
+|:-------------|:------------|:------------|
+| [Get Key from TrustFrameworkKeySet](../api/trustframeworkkeyset-getkey.md)       | [trustFrameworkKey_v2](trustframeworkkey_v2.md)  | Read properties and members of trustFrameworkKeySet.                                                 |
+| [Patch Key in TrustFrameworkKeySet](../api/trustframeworkkeyset-patchkeystatus.md)       | None                                  | Update target key status in trustFrameworkKeySet.
+
+### POST and PUT Key operation in TrustFrameworkKeySet are not supported for trustFrameworkKey_v2.
 
 ## Properties
 
@@ -37,8 +46,6 @@ Represents a JWK (JSON Web Key). TrustFrameworkKey is a JSON data structure that
 | nbf | int | This value is a NumericDate as defined in RFC 7519 (A JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds.) |
 | exp | int | This value is a NumericDate as defined in RFC 7519 (A JSON numeric value representing the number of seconds from 1970-01-01T00:00:00Z UTC until the specified UTC date/time, ignoring leap seconds.) |
 
-
-
 ## JSON representation
 
 Here's a JSON representation of the resource.
@@ -48,7 +55,7 @@ Here's a JSON representation of the resource.
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.trustFrameworkKey",
+  "@odata.type": "microsoft.graph.trustFrameworkKey_v2",
   "baseType": null
 }-->
 
@@ -78,7 +85,7 @@ Here's a JSON representation of the resource.
 2019-02-04 14:57:30 UTC -->
 <!-- {
   "type": "#page.annotation",
-  "description": "trustFrameworkKey resource",
+  "description": "trustFrameworkKey_v2 resource",
   "keywords": "",
   "section": "documentation",
   "tocPath": ""

--- a/api-reference/beta/resources/trustframeworkkeyset.md
+++ b/api-reference/beta/resources/trustframeworkkeyset.md
@@ -36,6 +36,7 @@ Represents a trust framework keyset/policy key. The Identity Experience framewor
 |:-------------|:------------|:------------|
 |id|String| Unique identifier of the trustframework keyset |
 |keys|[trustFrameworkKey](trustframeworkkey.md) collection| A collection of the keys. |
+|keys_v2|[trustFrameworkKey_v2](trustframeworkkey_v2.md) collection| A collection of the keys. |
 
 ## Relationships
 


### PR DESCRIPTION
In TrustFrameworkPolicies, secrets are stored which allow the framework to access different services on behalf of the application. Introducing new functionality using keys_v2 to support entity type operations like get keys and patch the key status for a key within keyset.