### PR TITLE
Fix Graph API app proxy application creation sample

### DIFF
--- a/concepts/application-proxy-configure-api.md
+++ b/concepts/application-proxy-configure-api.md
@@ -286,7 +286,7 @@ Content-type: application/json
 
 {
     "identifierUris": [
-        "https://contosoiwaapp-contoso.msappproxy.net"
+        "api://32977d3b-ee0e-4614-9f50-f583a07842d2"
     ],
     "web": {
         "redirectUris": [

--- a/concepts/application-proxy-configure-api.md
+++ b/concepts/application-proxy-configure-api.md
@@ -273,7 +273,7 @@ Also, configure the **onPremisesPublishing** property to set the internal and ex
 
 ### Step 2.1: Configure the URIs
 
-The request returns a `204 No content` response.
+The following request uses the value of **appId** for the **identifierUris** property. You can also use any other identifier that matches the application id URI format expected by Microsoft Entra ID. The request returns a `204 No content` response.
 
 # [HTTP](#tab/http)
 <!-- {


### PR DESCRIPTION
The current sample version does contain an error that prevents the creation of an application proxy app end-to-end via Microsoft Graph. Reason being the identifierUris to be set are incorrect in the sample.