### PR TITLE
Remove additional $filter doc from channels/getAllMessages, which is added by mistake

### DIFF
--- a/api-reference/beta/api/channel-getallretainedmessages.md
+++ b/api-reference/beta/api/channel-getallretainedmessages.md
@@ -54,16 +54,6 @@ This method supports the following OData query parameters to help customize the 
 | $filter | The [$filter](/graph/query-parameters#filter-parameter) query parameter supports date and time range queries on the **lastModifiedDateTime** property.|
 | $top    | Use the [$top](/graph/query-parameters#top-parameter) query parameter to control the number of items per response.|
 
-The following table lists examples that show how to use the `$filter` parameter.
-
-|Scenario                                  | `$filter` parameter                                                                       |Possible values                                                                                             |
-|:-----------------------------------------|:---------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------|
-|Get messages sent by user identity type   |$filter=from/user/userIdentityType eq '{teamworkUserIdentityType}'                      |aadUser, onPremiseAadUser, anonymousGuest, federatedUser, personalMicrosoftAccountUser, skypeUser, phoneUser|
-|Get messages sent by application type     |$filter=from/application/applicationIdentityType eq '{teamworkApplicationIdentity}'     |aadApplication, bot, tenantBot, office365Connector, outgoingWebhook                                         |
-|Get messages sent by user ID              |$filter=from/user/id eq '{oid}'                                                         ||
-|Get control (system event) messages        |$filter=messageType eq 'systemEventMessage'                                             ||
-|Exclude control (system event) messages   |$filter=messageType ne 'systemEventMessage'                                             ||
-
 ## Request headers
 
 |Name|Description|


### PR DESCRIPTION
This was meant for Teams chats only.