### PR TITLE
Update throttling-limits.md

### DIFF
--- a/concepts/throttling-limits.md
+++ b/concepts/throttling-limits.md
@@ -138,9 +138,9 @@ The following table lists base request costs. Any requests not listed have a bas
 | GET | `applications` | 2 | 0 |
 | GET | `applications/{id}/extensionProperties` | 2 | 0 |
 | GET | `contracts` | 3 | 0 |
-| POST | `directoryObjects/getByIds` |  3 | 0 |
+| POST | `directoryObjects/getByIds` | 5 | 0 |
 | GET | `domains/{id}/domainNameReferences` | 4 | 0 |
-| POST | `getObjectsById` | 3 | 0 |
+| POST | `getObjectsById` | 5 | 0 |
 | GET | `groups/{id}/members` | 3 | 0 |
 | GET | `groups/{id}/transitiveMembers` | 5 | 0 |
 | POST | `isMemberOf` | 4 | 0 |
@@ -176,6 +176,8 @@ Other factors that affect a request cost:
 
 > [!NOTE]
 > A request cost can never be lower than 1. Any request cost that applies to a request path starting with `me/` also applies to equivalent requests starting with `users/{id | userPrincipalName}/`.
+>
+> Using `$select` for `directoryObjects/getByIds` and `getObjectsById` decreases cost by 2
 
 ### Additional headers
 

--- a/concepts/throttling-limits.md
+++ b/concepts/throttling-limits.md
@@ -175,9 +175,8 @@ Other factors that affect a request cost:
 - Creating a user in a Microsoft Entra ID B2C tenant increases cost by 4
 
 > [!NOTE]
-> A request cost can never be lower than 1. Any request cost that applies to a request path starting with `me/` also applies to equivalent requests starting with `users/{id | userPrincipalName}/`.
->
-> Using `$select` for `directoryObjects/getByIds` and `getObjectsById` decreases cost by 2
+> - A request cost can never be lower than 1. Any request cost that applies to a request path starting with `me/` also applies to equivalent requests starting with `users/{id | userPrincipalName}/`.
+> - Using `$select` for `directoryObjects/getByIds` and `getObjectsById` decreases the cost by 2.
 
 ### Additional headers
 

--- a/concepts/throttling-limits.md
+++ b/concepts/throttling-limits.md
@@ -176,7 +176,7 @@ Other factors that affect a request cost:
 
 > [!NOTE]
 > - A request cost can never be lower than 1. Any request cost that applies to a request path starting with `me/` also applies to equivalent requests starting with `users/{id | userPrincipalName}/`.
-> - Using `$select` for `directoryObjects/getByIds` and `getObjectsById` decreases the cost by 2.
+> - Using `$select` for `directoryObjects/getByIds` and `getObjectsById` will result in 2 ResourceUnits.
 
 ### Additional headers
 


### PR DESCRIPTION
Updating Base Resource Unit Cost for directoryObjects/getByIds and getObjectsById from 3 to 5.

Also, a note stating: "Using $select for directoryObjects/getByIds and getObjectsById decreases cost by 2"

**Instructions:** _Add any supporting information, such as a description of the PR changes, here._





---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
