### PR TITLE
Update educationclass-delete-members.md - fix delete example

### DIFF
--- a/api-reference/beta/api/educationclass-delete-members.md
+++ b/api-reference/beta/api/educationclass-delete-members.md
@@ -53,7 +53,7 @@ The following example shows a request.
   "sampleKeys": ["11003", "14008"]
 }-->
 ```http
-DELETE https://graph.microsoft.com/beta/education/classes/11003/members/14008
+DELETE https://graph.microsoft.com/beta/education/classes/11003/members/14008/$ref
 ```
 
 # [JavaScript](#tab/javascript)

--- a/api-reference/v1.0/api/educationclass-delete-members.md
+++ b/api-reference/v1.0/api/educationclass-delete-members.md
@@ -50,7 +50,7 @@ The following example shows a request.
   "name": "create_educationclass_from_educationschool_1"
 }-->
 ```http
-DELETE https://graph.microsoft.com/v1.0/education/classes/{class-id}/members/{member-id}
+DELETE https://graph.microsoft.com/v1.0/education/classes/{class-id}/members/{member-id}/$ref
 ```
 
 # [JavaScript](#tab/javascript)


### PR DESCRIPTION
example needed to include $ref to show deletion of member.  Without $ref, will delete whole class.   Documentation showed examples both ways, and this updated clarifies correct syntax.

**Instructions:** _Add any supporting information, such as a description of the PR changes, here._





---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
