### PR TITLE
Update Post method name in create-requests.md

### DIFF
--- a/concepts/sdks/create-requests.md
+++ b/concepts/sdks/create-requests.md
@@ -118,7 +118,7 @@ Retrieving a list of entities is similar to retrieving a single entity, except o
 
 ---
 
-The object returned when retrieving a list of entities is likely be a paged collection. For details about how to get the complete list of entities, see [paging through a collection](../paging.md).
+The object returned when retrieving a list of entities will likely be a paged collection. For details about how to get the complete list of entities, see [paging through a collection](../paging.md).
 
 ## Access an item of a collection
 
@@ -224,7 +224,7 @@ Delete requests are constructed in the same way as requests to retrieve an entit
 
 ## Make a POST request to create a new entity
 
-For SDKs that support a fluent style, new items can be added to collections with an `Add` method. For template-based SDKs, the request object exposes a `post` method. For PowerShell, a `New-*` command accepts parameters that map to the entity to add. The created entity is returned from the call.
+For fluent style and template-based SDKs, new items can be added to collections with a `Post` method. For PowerShell, a `New-*` command accepts parameters that map to the entity to add. The created entity is returned from the call.
 
 # [C#](#tab/csharp)
 

--- a/concepts/sdks/create-requests.md
+++ b/concepts/sdks/create-requests.md
@@ -222,7 +222,7 @@ Delete requests are constructed in the same way as requests to retrieve an entit
 
 ---
 
-## Make a POST request to create a new entity
+## Creating a new entity with POST
 
 For fluent style and template-based SDKs, new items can be added to collections with a `Post` method. For PowerShell, a `New-*` command accepts parameters that map to the entity to add. The created entity is returned from the call.
 
@@ -292,7 +292,7 @@ Most updates in Microsoft Graph are performed using a `PATCH` method; therefore,
 
 ## Use HTTP headers to control request behavior
 
-You can attach custom headers to a request using a `Header()` function. For PowerShell, adding headers is only possible with the `Invoke-GraphRequest` method. Some Microsoft Graph scenarios use custom headers to adjust the behavior of the request.
+You can attach custom headers to a request using the `Headers` collection. For PowerShell, adding headers is only possible with the `Invoke-GraphRequest` method. Some Microsoft Graph scenarios use custom headers to adjust the behavior of the request.
 
 # [C#](#tab/csharp)
 

--- a/concepts/sdks/create-requests.md
+++ b/concepts/sdks/create-requests.md
@@ -224,7 +224,7 @@ Delete requests are constructed in the same way as requests to retrieve an entit
 
 ## Creating a new entity with POST
 
-For fluent style and template-based SDKs, new items can be added to collections with a `Post` method. For PowerShell, a `New-*` command accepts parameters that map to the entity to add. The created entity is returned from the call.
+For fluent style and template-based SDKs, new items can be added to collections with a `POST` method. For PowerShell, a `New-*` command accepts parameters that map to the entity to add. The created entity is returned from the call.
 
 # [C#](#tab/csharp)
 
@@ -258,7 +258,7 @@ For fluent style and template-based SDKs, new items can be added to collections 
 
 ## Updating an existing entity with PATCH
 
-Most updates in Microsoft Graph are performed using a `Patch` method; therefore, it's only necessary to include the properties you want to change in the object you pass.
+Most updates in Microsoft Graph are performed using a `PATCH` method; therefore, it's only necessary to include the properties you want to change in the object you pass.
 
 # [C#](#tab/csharp)
 

--- a/concepts/sdks/create-requests.md
+++ b/concepts/sdks/create-requests.md
@@ -258,7 +258,7 @@ For fluent style and template-based SDKs, new items can be added to collections 
 
 ## Updating an existing entity with PATCH
 
-Most updates in Microsoft Graph are performed using a `PATCH` method; therefore, it's only necessary to include the properties you want to change in the object you pass.
+Most updates in Microsoft Graph are performed using a `Patch` method; therefore, it's only necessary to include the properties you want to change in the object you pass.
 
 # [C#](#tab/csharp)
 
@@ -326,7 +326,7 @@ You can attach custom headers to a request using the `Headers` collection. For P
 
 ## Provide custom query parameters
 
-For SDKs that support a fluent style, you can provide custom query parameter values using a list of `QueryOptions` objects. For template-based SDKs, the parameters are URL-encoded and added to the request URI. For PowerShell and Go, defined query parameters for a given API are exposed as parameters to the corresponding command.
+For SDKs that support the fluent style, you can provide custom query parameter values using the `QueryParameters` object. For template-based SDKs, the parameters are URL-encoded and added to the request URI. For PowerShell and Go, defined query parameters for a given API are exposed as parameters to the corresponding command.
 
 # [C#](#tab/csharp)
 


### PR DESCRIPTION
- for fluent style SDKs, new items are added with a `Post` method, there is no `Add` method
- `Header()` function -> `Headers` collection
- a list of `QueryOptions` objects -> the `QueryParameters` object
- updated a subheader
- restored a missing word





---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
