### PR TITLE
Update user-list-events.md

### DIFF
--- a/api-reference/beta/api/user-list-events.md
+++ b/api-reference/beta/api/user-list-events.md
@@ -68,7 +68,11 @@ GET /me/calendarGroups/{id}/calendars/{id}/events
 GET /users/{id | userPrincipalName}/calendarGroups/{id}/calendars/{id}/events
 ```
 ## Optional query parameters
-This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query-parameters) to help customize the response.
+
+> [!NOTE]
+> You can't use the `$filter` parameter to filter on the **recurrence** property.
+
 ## Request headers
 | Name       | Type | Description|
 |:-----------|:------|:----------|
@@ -82,8 +86,8 @@ Don't supply a request body for this method.
 ## Response
 
 If successful, this method returns a `200 OK` response code and collection of [event](../resources/event.md) objects in the response body.
-## Example
-##### Request 1
+## Examples
+### Example 1: Get all user's events
 The first example gets all the user's events. It specifies the following:
 
 - A `Prefer: outlook.timezone` header to get date time values returned in Pacific Standard Time.
@@ -91,6 +95,7 @@ The first example gets all the user's events. It specifies the following:
 
 The request does not specify any `Prefer: outlook.body-content-type` header to indicate a specific format for the returned event body.
 
+#### Request
 
 # [HTTP](#tab/http)
 <!-- {
@@ -136,7 +141,7 @@ Prefer: outlook.timezone="Pacific Standard Time"
 
 ---
 
-##### Response 1
+#### Response
 The following example shows the response. Because no `Prefer: outlook.body-content-type` header was specified, the **body** property is returned in the default HTML format.
 <!-- {
   "blockType": "response",
@@ -218,10 +223,12 @@ Preference-Applied: outlook.timezone="Pacific Standard Time"
 }
 ```
 
-##### Request 2
-The second example shows how to use a `Prefer: outlook.body-content-type="text"` header to get the **body** property of the specified message in text format.
+### Example 2: Get the body propery of the message
+The following example shows how to use a `Prefer: outlook.body-content-type="text"` header to get the **body** property of the specified message in text format.
 
 The request also uses a `$select` query parameter to return specific properties. Without a `$select` parameter, all of the event properties will be returned.
+
+#### Request
 
 # [HTTP](#tab/http)
 <!-- {
@@ -267,7 +274,7 @@ Prefer: outlook.body-content-type="text"
 
 ---
 
-##### Response 2
+#### Response
 The following example shows the response. The **body** property is returned in text format.
 
 <!-- {

--- a/api-reference/v1.0/api/user-list-events.md
+++ b/api-reference/v1.0/api/user-list-events.md
@@ -67,7 +67,7 @@ GET /me/calendarGroups/{id}/calendars/{id}/events
 GET /users/{id | userPrincipalName}/calendarGroups/{id}/calendars/{id}/events
 ```
 ## Optional query parameters
-This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query-parameters) to help customize the response.
 
 > [!NOTE]
 > You can't use the `$filter` parameter to filter on the **recurrence** property.

--- a/api-reference/v1.0/api/user-list-events.md
+++ b/api-reference/v1.0/api/user-list-events.md
@@ -68,11 +68,10 @@ GET /users/{id | userPrincipalName}/calendarGroups/{id}/calendars/{id}/events
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+
 > [!NOTE]
->
-> ### Unsupported properties for the `$filter` parameter
-> The following properties are not supported to use with the `$filter` parameter:
-> + `recurrence`
+> You can't use the `$filter` parameter to filter on the **recurrence** property.
+
 ## Request headers
 | Name       | Type | Description |
 |:---------------|:--------|:--------|
@@ -86,8 +85,8 @@ Don't supply a request body for this method.
 ## Response
 
 If successful, this method returns a `200 OK` response code and collection of [event](../resources/event.md) objects in the response body.
-## Example
-##### Request
+## Examples
+### Request
 The following example shows a request. It specifies the following:
 
 - A `Prefer: outlook.timezone` header to get date time values returned in Pacific Standard Time.
@@ -138,7 +137,7 @@ Prefer: outlook.timezone="Pacific Standard Time"
 
 ---
 
-##### Response
+### Response
 The following example shows the response. The **body** property is returned in the default HTML format.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/user-list-events.md
+++ b/api-reference/v1.0/api/user-list-events.md
@@ -68,6 +68,11 @@ GET /users/{id | userPrincipalName}/calendarGroups/{id}/calendars/{id}/events
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+> [!NOTE]
+>
+> ### Unsupported properties for the `$filter` parameter
+> The following properties are not supported to use with the `$filter` parameter:
+> + `recurrence`
 ## Request headers
 | Name       | Type | Description |
 |:---------------|:--------|:--------|


### PR DESCRIPTION
# Added Note For Unsupported Properties For The `$filter` Parameter
The [user-list-events](https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/v1.0/api/user-list-events.md) page includes no list of which properties will not work in a `$filter` query parameter, so I have added a note to list any, starting with the  '`recurrence`' property as the first in the list.

I added a descriptive H3 to ensure that it was something that people could both find and link to easily.