### PR TITLE
working elsewhere is 0, not 4

### DIFF
--- a/api-reference/beta/resources/scheduleinformation.md
+++ b/api-reference/beta/resources/scheduleinformation.md
@@ -18,7 +18,7 @@ Represents the availability of a user, distribution list, or resource (room or e
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|availabilityView |String |Represents a merged view of availability of all the items in `scheduleItems`. The view consists of time slots. Availability during each time slot is indicated with: `0`= free, `1`= tentative, `2`= busy, `3`= out of office, `4`= working elsewhere.|
+|availabilityView |String |Represents a merged view of availability of all the items in `scheduleItems`. The view consists of time slots. Availability during each time slot is indicated with: `0`= free or working elswhere, `1`= tentative, `2`= busy, `3`= out of office.<br><br>**Note:** Working elsewhere is set to `0` instead of `4` for backward compatibility. For details, see the [Q&A](https://learn.microsoft.com/en-us/answers/questions/309571/working-elsewhere-in-getschedules-availabilityview).|
 |error |[freeBusyError](freebusyerror.md) |Error information from attempting to get the availability of the user, distribution list, or resource. |
 |scheduleId |String |An SMTP address of the user, distribution list, or resource, identifying an instance of **scheduleInformation**. |
 |scheduleItems |[scheduleItem](scheduleitem.md) collection |Contains the items that describe the availability of the user or resource. |

--- a/api-reference/v1.0/resources/scheduleinformation.md
+++ b/api-reference/v1.0/resources/scheduleinformation.md
@@ -16,7 +16,7 @@ Represents the availability of a user, distribution list, or resource (room or e
 ## Properties
 | Property       | Type    |Description|
 |:---------------|:--------|:----------|
-|availabilityView |String |Represents a merged view of availability of all the items in `scheduleItems`. The view consists of time slots. Availability during each time slot is indicated with: `0`= free, `1`= tentative, `2`= busy, `3`= out of office, `0`= working elsewhere.<br>`working else` is actually suppose to be equal to `4`, thought due to backwards compatibility it is currently set as is (https://learn.microsoft.com/en-us/answers/questions/309571/working-elsewhere-in-getschedules-availabilityview)|
+|availabilityView |String |Represents a merged view of availability of all the items in `scheduleItems`. The view consists of time slots. Availability during each time slot is indicated with: `0`= free or working elswhere, `1`= tentative, `2`= busy, `3`= out of office.<br><br>**Note:** Working elsewhere is set to `0` instead of `4` for backward compatibility. For details, see the [Q&A](https://learn.microsoft.com/en-us/answers/questions/309571/working-elsewhere-in-getschedules-availabilityview).|
 |error |[freeBusyError](freebusyerror.md) |Error information from attempting to get the availability of the user, distribution list, or resource. |
 |scheduleId |String |An SMTP address of the user, distribution list, or resource, identifying an instance of **scheduleInformation**. |
 |scheduleItems |[scheduleItem](scheduleitem.md) collection |Contains the items that describe the availability of the user or resource. |

--- a/api-reference/v1.0/resources/scheduleinformation.md
+++ b/api-reference/v1.0/resources/scheduleinformation.md
@@ -16,7 +16,7 @@ Represents the availability of a user, distribution list, or resource (room or e
 ## Properties
 | Property       | Type    |Description|
 |:---------------|:--------|:----------|
-|availabilityView |String |Represents a merged view of availability of all the items in `scheduleItems`. The view consists of time slots. Availability during each time slot is indicated with: `0`= free, `1`= tentative, `2`= busy, `3`= out of office, `4`= working elsewhere.|
+|availabilityView |String |Represents a merged view of availability of all the items in `scheduleItems`. The view consists of time slots. Availability during each time slot is indicated with: `0`= free, `1`= tentative, `2`= busy, `3`= out of office, `0`= working elsewhere.<br>`working else` is actually suppose to be equal to `4`, thought due to backwards compatibility it is currently set as is (https://learn.microsoft.com/en-us/answers/questions/309571/working-elsewhere-in-getschedules-availabilityview)|
 |error |[freeBusyError](freebusyerror.md) |Error information from attempting to get the availability of the user, distribution list, or resource. |
 |scheduleId |String |An SMTP address of the user, distribution list, or resource, identifying an instance of **scheduleInformation**. |
 |scheduleItems |[scheduleItem](scheduleitem.md) collection |Contains the items that describe the availability of the user or resource. |


### PR DESCRIPTION
If one reqest getschedule and has a "working elsewhere" event it is not shown as 4 but 0. This is true if called via java API or via Postman.

Also I found this article from 2021: https://learn.microsoft.com/en-us/answers/questions/309571/working-elsewhere-in-getschedules-availabilityview

**Instructions:** _Add any supporting information, such as a description of the PR changes, here._





---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
