### PR TITLE
Update itemreference.md

### DIFF
--- a/api-reference/beta/resources/itemreference.md
+++ b/api-reference/beta/resources/itemreference.md
@@ -20,7 +20,7 @@ Provides information necessary to address a [driveItem](driveitem.md) or a [list
 | driveType     | String            | Identifies the type of drive. Only returned if the item is located in a [drive][].  See [drive][] resource for values.
 | id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.
-| path          | String            | Path that can be used to navigate to the item. Read-only.
+| path          | String            | Percent-encoded path that can be used to navigate to the item. Read-only.
 | shareId       | String            | A unique identifier for a shared resource that can be accessed via the [Shares][] API.
 | sharepointIds | [sharepointIds][] | Returns identifiers useful for SharePoint REST compatibility. Read-only.
 | siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource or the parent list of the listItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site?view=graph-rest-beta&preserve-view=true#id-property) of the site. <br>For OneDrive, this property is not populated.
@@ -61,7 +61,7 @@ To address a **driveItem** from an **itemReference** resource, construct a URL o
 GET https://graph.microsoft.com/v1.0/drives/{driveId}/items/{id}
 ```
 
-The **path** value is an API path relative to the target drive, for example: `/drive/root:/Documents/myfile.docx`.
+The **path** value is a percent-encoded API path relative to the target drive, for example: `/drive/root:/Documents/my%20file.docx`.
 
 To retrieve the human-readable path for a breadcrumb, you can safely ignore everything up to the first `:` in the path string.
 

--- a/api-reference/v1.0/resources/itemreference.md
+++ b/api-reference/v1.0/resources/itemreference.md
@@ -21,7 +21,7 @@ The **itemReference** resource provides information necessary to address a [driv
 | driveType     | String            | Identifies the type of drive. Only returned if the item is located in a [drive][]. See [drive][] resource for values.
 | id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.
-| path          | String            | Path that can be used to navigate to the item. Read-only.
+| path          | String            | Percent-encoded path that can be used to navigate to the item. Read-only.
 | shareId       | String            | A unique identifier for a shared resource that can be accessed via the [Shares][] API.
 | sharepointIds | [sharepointIds][] | Returns identifiers useful for SharePoint REST compatibility. Read-only.
 | siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource or the parent list of the listItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site#id-property) of the site. <br>For OneDrive, this property is not populated.
@@ -62,7 +62,7 @@ To address a **driveItem** from an **itemReference** resource, construct a URL o
 GET https://graph.microsoft.com/v1.0/drives/{driveId}/items/{id}
 ```
 
-The **path** value is an API path relative to the target drive, for example: `/drive/root:/Documents/myfile.docx`.
+The **path** value is a percent-encoded API path relative to the target drive, for example: `/drive/root:/Documents/my%20file.docx`.
 
 To retrieve the human-readable path for a breadcrumb, you can safely ignore everything up to the first `:` in the path string.
 


### PR DESCRIPTION
Clarified that the path property is percent-encoded.

I opened an [issue](https://github.com/microsoftgraph/msgraph-sdk-java/issues/2027) on msgraph-sdk-java and I was suggested to try and update the documentation to make clear that `path` is a percent-encoded URL, so I propose the change in this PR.

---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
