### PR TITLE
Update metered API creation commands' parameter notation to avoid confusion when customer replace placeholders with real values.

### DIFF
--- a/concepts/metered-api-setup.md
+++ b/concepts/metered-api-setup.md
@@ -37,15 +37,15 @@ Use the following steps to create and link a **Microsoft.GraphServices/accounts*
 
 # [Azure Cloud Shell](#tab/azurecloudshell)
   ```PowerShell
-  az resource create --resource-group myRG --name myGraphAppBilling --resource-type Microsoft.GraphServices/accounts --properties  "{\"appId\": \"myAppGUID\"}" --location Global --subscription mySubscriptionGUID
+  az resource create --resource-group "<myRG>" --name "<myGraphAppBilling>" --resource-type Microsoft.GraphServices/accounts --properties  "{\"appId\": \"<myAppGUID>\"}" --location Global --subscription "<mySubscriptionGUID>"
   ```
 # [PowerShell](#tab/powershell)
   ```PowerShell
-  az resource create --resource-group myRG --name myGraphAppBilling --resource-type Microsoft.GraphServices/accounts --properties  "{\`"appId\`": \`"myAppGUID\`"}" --location Global --subscription mySubscriptionGUID
+  az resource create --resource-group "<myRG>" --name "<myGraphAppBilling>" --resource-type Microsoft.GraphServices/accounts --properties  "{\`"appId\`": \`"<myAppGUID>\`"}" --location Global --subscription "<mySubscriptionGUID>"
   ```
 # [Windows Command Prompt](#tab/commandprompt)
   ```CommandPrompt
-  az resource create --resource-group myRG --name myGraphAppBilling --resource-type Microsoft.GraphServices/accounts --properties  "{""appId"": ""myAppGUID""}" --location Global --subscription mySubscriptionGUID
+  az resource create --resource-group "<myRG>" --name "<myGraphAppBilling>" --resource-type Microsoft.GraphServices/accounts --properties  "{""appId"": ""<myAppGUID>""}" --location Global --subscription "<mySubscriptionGUID>"
   ```
 
 ---
@@ -54,27 +54,27 @@ Use the following steps to create and link a **Microsoft.GraphServices/accounts*
   |:--------------------------|:----------------------------------------|
   | myRG | The name of an existing Azure resource group to add the newly created resource to. |
   | myGraphAppBilling | The name you want to give to this resource instance. |
-  | myAppGUID | The Application (client) ID of the application being enabled, provided as a string parameter; for example, 00000000-0000-0000-0000-000000000000. |
-  | mySubscriptionGUID | The ID of the Azure subscription that will receive billing events, provided as a string parameter; for example, 00000000-0000-0000-0000-000000000000. |
+  | myAppGUID | The Application (client) ID of the application being enabled, provided as a string parameter; for example, 123e4567-e89b-12d3-a456-426655440000. |
+  | mySubscriptionGUID | The ID of the Azure subscription that will receive billing events, provided as a string parameter; for example, 123e4567-e89b-12d3-a456-426655440000. |
 
   A successful JSON result will look something like this:
 
 ```
 {
   "extendedLocation": null,
-  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.GraphServices/accounts/myGraphAppBilling",
+  "id": "/subscriptions/<mySubscriptionGUID>/resourceGroups/<myRG>/providers/Microsoft.GraphServices/accounts/<myGraphAppBilling>",
   "identity": null,
   "kind": null,
   "location": "Global",
   "managedBy": null,
-  "name": "myGraphAppBilling",
+  "name": "<myGraphAppBilling>",
   "plan": null,
   "properties": {
-    "appId": "00000000-0000-0000-0000-000000000000",
-    "billingPlanId": "00000000-0000-0000-0000-000000000000",
+    "appId": "<myAppGUID>",
+    "billingPlanId": "123e4567-e89b-12d3-a456-426655440000",
     "provisioningState": "Succeeded"
   },
-  "resourceGroup": "myRG",
+  "resourceGroup": "<myRG>",
   "sku": null,
   "systemData": {
     "createdAt": "2023-01-31T00:12:20.7893671Z",
@@ -108,16 +108,16 @@ A successful JSON result will look something like this:
     "changedTime": "2023-04-25T18:12:30.586342+00:00",
     "createdTime": "2023-04-25T18:02:30.141407+00:00",
     "extendedLocation": null,
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.GraphServices/accounts/myGraphAppBilling",
+    "id": "/subscriptions/<mySubscriptionGUID>/resourceGroups/<myRG>/providers/Microsoft.GraphServices/accounts/<myGraphAppBilling>",
     "identity": null,
     "kind": null,
     "location": "global",
     "managedBy": null,
-    "name": "myGraphAppBilling",
+    "name": "<myGraphAppBilling>",
     "plan": null,
     "properties": null,
     "provisioningState": "Succeeded",
-    "resourceGroup": "myRG",
+    "resourceGroup": "<myRG>",
     "sku": null,
     "tags": null,
     "type": "Microsoft.GraphServices/accounts"
@@ -128,7 +128,7 @@ A successful JSON result will look something like this:
 3. With the values returned in step 2, use **az resource show** to show the full details of the resource. Copy the following command into your command-line interface, replace the parameters listed in the table with your own values, and type <**Enter**>. If the command succeeds, the response will include a JSON representation of the requested resource.
 
 ```PowerShell
-  az resource show --resource-group myRg --name myGraphAppBilling --resource-type Microsoft.GraphServices/accounts
+  az resource show --resource-group "<myRG>" --name "<myGraphAppBilling>" --resource-type Microsoft.GraphServices/accounts
 ```
 
 | Parameter | Description |
@@ -141,18 +141,18 @@ A successful JSON result will look something like this:
 ```
 {
   "extendedLocation": null,
-  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myRG/providers/Microsoft.GraphServices/accounts/myGraphAppBilling",
+  "id": "/subscriptions/<mySubscriptionGUID>/resourceGroups/<myRG>/providers/Microsoft.GraphServices/accounts/<myGraphAppBilling>",
   "identity": null,
   "kind": null,
   "location": "Global",
   "managedBy": null,
-  "name": "myGraphAppBilling",
+  "name": "<myGraphAppBilling>",
   "plan": null,
   "properties": {
-    "appId": "00000000-0000-0000-0000-000000000000",
-    "billingPlanId": "00000000-0000-0000-0000-000000000000"
+    "appId": "<myAppGUID>",
+    "billingPlanId": "123e4567-e89b-12d3-a456-426655440000"
   },
-  "resourceGroup": "myRG",
+  "resourceGroup": "<myRG>",
   "sku": null,
   "tags": null,
   "type": "microsoft.graphservices/accounts"


### PR DESCRIPTION
The metered API enablement steps have some inconsistencies in how the placeholder texts are used in the input commands vs. the output examples. In some cases, the parameter name is used but in others the empty GUID value is used.

This has been unclear for customers as we have seen an increase in customer support requests where customers have put values in the wrong place since the placeholder texts aren't used consistently.

The changes made follow the placeholder text notations used in other Microsoft documentation pages, such as [Create an Azure KeyVault with Azure PowerShell](https://learn.microsoft.com/en-us/azure/key-vault/general/quick-create-powershell), [Create a single database](https://learn.microsoft.com/en-us/azure/azure-sql/database/single-database-create-quickstart?view=azuresql&tabs=azure-cli), and [GUID function](https://learn.microsoft.com/en-us/power-platform/power-fx/reference/function-guid).