### PR TITLE
Warning fix: Update driveitem-move.md

### DIFF
--- a/api-reference/beta/api/driveitem-move.md
+++ b/api-reference/beta/api/driveitem-move.md
@@ -1,12 +1,14 @@
 ---
 author: spgraph-docs-team
 description: "Move a driveItem to a new parent folder."
-title: driveItem: move
+title: "driveItem: move"
 ms.localizationpriority: medium
 ms.subservice: "sharepoint"
 doc_type: apiPageType
 ---
+
 # driveItem: move
+
 Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]


### PR DESCRIPTION
Fixed YAML configuration.

This PR fixes the following warning:
![image](https://github.com/microsoftgraph/microsoft-graph-docs-contrib/assets/26866873/00b32af8-faae-4e34-90be-419aad25111d)