### PR TITLE
Warning fix: author-not-found

### DIFF
--- a/api-reference/beta/resources/channelsummary.md
+++ b/api-reference/beta/resources/channelsummary.md
@@ -2,7 +2,7 @@
 title: "channelSummary resource type"
 description: "Contains information about a channel in Microsoft Teams, including numbers of guests, members, and owners, and whether the channel includes members from other tenants."
 ms.localizationpriority: medium
-author: "sonalikallanimicrosoft"
+author: "rupanshoo"
 ms.subservice: "teams"
 doc_type: resourcePageType
 ---


### PR DESCRIPTION
Fixed the 'author not found' issue by setting the author from the v1.0 topic to the beta topic.