### PR TITLE
Char typo in 'Configure application access to online meetings or virtual events'

### DIFF
--- a/concepts/cloud-communication-online-meeting-application-access-policy.md
+++ b/concepts/cloud-communication-online-meeting-application-access-policy.md
@@ -28,7 +28,7 @@ The following table compares application access policy for online meeting and vi
 
 - _Policy_1_ contains one app ID (_app_1_)
 - _Policy_2_ contains one app ID (_app_2_)
-- _Policy_3_) contains both app IDs (_app_1_ and _app_2_)
+- _Policy_3_ contains both app IDs (_app_1_ and _app_2_)
 
 | Scenario | Online meeting | Virtual event |
 |----------|----------------|---------------|


### PR DESCRIPTION
There was a typo on the page "Configure application access to online meetings or virtual events". Under the heading "Compare application access policy for online meetings and virtual events", there's a misplaced `)` in the list of policies.

