### PR TITLE
Updated todo.md

### DIFF
--- a/concepts/toolkit/components/todo.md
+++ b/concepts/toolkit/components/todo.md
@@ -34,7 +34,6 @@ You can use the following attributes and properties to customize the component.
 | Attribute | Property | Description |
 | -- | -- | -- |
 | read-only | readOnly | A Boolean to set the task interface to be read only (no adding or removing tasks). Default is `false`. |
-| hide-header | hideHeader | A Boolean to show or hide the header of the component. Default is `false`. |
 | initial-id="folder_id" | initialId | A string ID to set the initially displayed folder to the provided ID. |
 | target-id="folder_id"| targetId | A string ID to lock the tasks interface to the provided folder ID. |
 | N/A | isNewTaskVisible  | Determines whether new task view is visible at render. |

--- a/concepts/toolkit/components/todo.md
+++ b/concepts/toolkit/components/todo.md
@@ -35,7 +35,6 @@ You can use the following attributes and properties to customize the component.
 | -- | -- | -- |
 | read-only | readOnly | A Boolean to set the task interface to be read only (no adding or removing tasks). Default is `false`. |
 | hide-header | hideHeader | A Boolean to show or hide the header of the component. Default is `false`. |
-| hide-options | hideOptions | A Boolean to show or hide the options in tasks. Default is `false`.
 | initial-id="folder_id" | initialId | A string ID to set the initially displayed folder to the provided ID. |
 | target-id="folder_id"| targetId | A string ID to lock the tasks interface to the provided folder ID. |
 | N/A | isNewTaskVisible  | Determines whether new task view is visible at render. |


### PR DESCRIPTION
The documentation explains that, among the other properties for the ToDo control, there is the `hideOptions` property but it doesn't seems to be used anywhere in the code and also, to support my assumption, if it's set to `true` nothing changes in the UI. That said I've updated the documentation to remove the property from the available properties of the ToDo control.

---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
