### PR TITLE
Interval format error

### DIFF
--- a/api-reference/beta/resources/synchronization-synchronizationschedule.md
+++ b/api-reference/beta/resources/synchronization-synchronizationschedule.md
@@ -19,7 +19,7 @@ Defines the schedule used to run a [synchronizationJob](synchronization-synchron
 | Property       | Type    |Description|
 |:---------------|:--------|:----------|
 |expiration|DateTimeOffset|Date and time when this job will expire. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`.|
-|interval|Duration|The interval between synchronization iterations. The value is represented in ISO 8601 format for durations. For example, `PT1M` represents a period of 1 month.|
+|interval|Duration|The interval between synchronization iterations. The value is represented in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)  format for durations. For example, `P1M` represents a period of one month and `PT1M` represents a period of one minute.|
 |state|synchronizationScheduleState|The possible values are: `Active`, `Disabled`, `Paused`.|
 
 

--- a/api-reference/v1.0/resources/synchronization-synchronizationschedule.md
+++ b/api-reference/v1.0/resources/synchronization-synchronizationschedule.md
@@ -17,7 +17,7 @@ Defines the schedule used to run a [synchronizationJob](synchronization-synchron
 | Property       | Type    |Description|
 |:---------------|:--------|:----------|
 |expiration|DateTimeOffset|Date and time when this job expires. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`.|
-|interval|Duration|The interval between synchronization iterations. The value is represented in ISO 8601 format for durations. For example, `PT1M` represents a period of one month.|
+|interval|Duration|The interval between synchronization iterations. The value is represented in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)  format for durations. For example, `P1M` represents a period of one month and `PT1M` represents a period of one minute.|
 |state|synchronizationScheduleState|The possible values are: `Active`, `Disabled`, `Paused`.|
 
 


### PR DESCRIPTION
The interval PT1M represents a period of one minute as per ISO 8601

If this is not the actual case in your software (in particular the provisioning Api) it would seem like a bug or you are not actually follow ISO 8601.

If either is the case please disregard this PR
