### PR TITLE
Add missing If-Match header 

### DIFF
--- a/api-reference/beta/api/businessscenarioplanner-delete-tasks.md
+++ b/api-reference/beta/api/businessscenarioplanner-delete-tasks.md
@@ -39,6 +39,7 @@ DELETE /solutions/businessScenarios/{businessScenarioId}/planner/tasks/{business
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
+| If-Match  | Last known ETag value for the **businessScenarioTask** to be updated. Required.|
 
 ## Request body
 
@@ -63,6 +64,7 @@ The following example shows a request.
 -->
 ``` http
 DELETE https://graph.microsoft.com/beta/solutions/businessScenarios/c5d514e6c6864911ac46c720affb6e4d/planner/tasks/pmc1rS1Io0C3rXQhyXIsNmUAOeIi
+If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 ```
 
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/businessscenariotask-update.md
+++ b/api-reference/beta/api/businessscenariotask-update.md
@@ -40,6 +40,7 @@ PATCH /solutions/businessScenarios/{businessScenarioId}/planner/tasks/{businessS
 |:---|:---|
 |Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
 |Content-Type|application/json. Required.|
+| If-Match  | Last known ETag value for the **businessScenarioTask** to be updated. Required.|
 
 ## Request body
 
@@ -82,6 +83,7 @@ The following example shows a request.
 ``` http
 PATCH https://graph.microsoft.com/beta/solutions/businessScenarios/c5d514e6c6864911ac46c720affb6e4d/planner/tasks/pmc1rS1Io0C3rXQhyXIsNmUAOeIi
 Content-Type: application/json
+If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 
 {
   "title": "Customer order #12010",


### PR DESCRIPTION
This PR contains changes related to the updating of a business scenario task. When using the API to create a POC, I have found that the eTag of the businessScenarioTask is required using the If-Match header when trying to update a task. I have updated the documentation and HTTP example to reflect this.

---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
