### PR TITLE
GroupMember.Read.All and User.ReadBasic.All as least-privileged permissions.

### DIFF
--- a/concepts/permissions-overview.md
+++ b/concepts/permissions-overview.md
@@ -109,7 +109,7 @@ This principle is applied to all relationships that are of [directoryObject](/gr
 
 For example, a group can have users, groups, applications, service principals, devices, and contacts as members. An app is granted the *GroupMember.Read.All* least privileged permission to [List group members](/graph/api/group-list-members). In the response object, only the **id** and **@odata.type** properties are populated for all the members that are returned. The other properties are indicated as `null`.
 
-To read the basic properties of a group's members that are users, the app needs at least the *User.Read.All* permission. To read the basic properties of a group's members that are groups, the app needs at least the *Group.Read.All* permission. To read the basic properties of a group's members that are devices, the app needs at least the *Device.Read.All* permission, and so on. However, as an alternative to the individual resource-level permissions, the app can be assigned at least the *Directory.Read.All* permission to read *all properties for all member types*.
+To read the basic properties of a group's members that are users, the app needs at least the *User.ReadBasic.All* permission. To read the basic properties of a group's members that are groups, the app needs at least the *GroupMember.Read.All* permission. To read the basic properties of a group's members that are devices, the app needs at least the *Device.Read.All* permission, and so on. However, as an alternative to the individual resource-level permissions, the app can be assigned at least the *Directory.Read.All* permission to read *all properties for all member types*.
 
 ### Example
 
@@ -198,7 +198,7 @@ Microsoft Graph exposes granular permissions that allow an app to request only t
 Consider the following examples:
 
 - An app needs to only read the profile information of the signed-in user. The app requires only the *User.Read* permission, which is the least privileged permission to access the signed-in user's information. Granting the app the *User.ReadWrite* permission makes it over-privileged because the app doesn't need to update the user's profile.
-- An app needs to read the groups in the tenant without a signed-in user. The app requires only the *Group.Read.All* application permission, which is the least privileged permission to read groups in the tenant without a signed-in user.
+- An app needs to read the groups in the tenant without a signed-in user. The app requires only the *GroupMember.Read.All* application permission, which is the least privileged permission to read groups in the tenant without a signed-in user.
 - An app needs to read or write to a calendar of the signed-in user. The app manages dynamic jobs, and syncs from the user's Outlook calendar to keep the app up-to-date so to schedule jobs for the user. Even though [getting](/graph/api/event-delta) the user's calendar data requires *Calendars.Read*, [updating](/graph/api/user-post-events) the calendar with scheduled jobs requires a higher privileged permission, *Calendars.ReadWrite*. In this case, the app should request *Calendars.ReadWrite*.
 
 Granting an application more privileges than it needs is a poor security practice that exposes an app to unauthorized and unintended access to data or operations. Also, requesting more permissions than necessary may cause users to refrain from consenting to an app, affecting an app's adoption and usage.


### PR DESCRIPTION
Hello, the documentation refers to Group.Read.All permissions and User.Read.All as least-privileged permissions. However, where possible, GroupMember.Read.All and User.ReadBasic.All should be used instead.

Please consider that Group.Read.All allows the app to read group properties and memberships, but it also _"grants the app access to the **contents** of the group; for example, conversations, files, notes, and so on."_ GroupMember.Read.All is the least-privileged permission which grants the app access to basic group properties and to group memberships.

You may refer to this page: https://learn.microsoft.com/en-us/graph/permissions-reference#groupreadall

Thanks for considering this PR as it's especially important for confidentiality of MS365 group data. 