### PR TITLE
Update batch-requests.md

### DIFF
--- a/concepts/sdks/batch-requests.md
+++ b/concepts/sdks/batch-requests.md
@@ -79,6 +79,6 @@ This example shows how to send multiple requests in a batch that are dependent o
 
 > [!NOTE]
 > ## Automatic batching for request limits
-> The Microsoft Graph SDK automatically handles batching requests with respect to the limit of 20 requests per batch. This means that if your code exceeds this limit, the SDK will split the requests into separate batches behind the scenes, ensuring that each batch complies with the limitation. You no longer need to manually implement logic to handle this batching limit, making your code cleaner and easier to manage.
+> The Microsoft Graph SDK automatically handles batching requests with respect to the limit of 20 requests per batch. This means that if your code exceeds this limit, the SDK will split the requests into separate batches behind the scenes, ensuring that each batch complies with the limitation. You no longer need to manually implement logic to handle this batching limit, which makes your code cleaner and easier to manage.
 
 

--- a/concepts/sdks/batch-requests.md
+++ b/concepts/sdks/batch-requests.md
@@ -22,6 +22,10 @@ The Microsoft Graph SDKs provide three classes to work with batch requests and r
 - **BatchRequestContent** - Simplifies creating the batch request payload. It contains multiple **BatchRequestStep** objects.
 - **BatchResponseContent** - Simplifies parsing the response from a batch request. It provides the ability to get all responses, get a specific response by ID, and get the `@odata.nextLink` property if present.
 
+### Automatic batching for request limits
+
+The Microsoft Graph SDK automatically handles batching requests with respect to the limit of 20 requests per batch. This means that if your code exceeds this limit, the SDK will split the requests into separate batches behind the scenes, ensuring that each batch complies with the limitation. You no longer need to manually implement logic to handle this batching limit, which makes your code cleaner and easier to manage.
+
 ## Simple batching example
 
 This example shows how to send multiple requests in a batch that are not dependent on each other. The requests can be run by the service in any order. This example gets the user and gets the user's calendar view for the current day.
@@ -77,8 +81,5 @@ This example shows how to send multiple requests in a batch that are dependent o
 
 ---
 
-> [!NOTE]
-> ## Automatic batching for request limits
-> The Microsoft Graph SDK automatically handles batching requests with respect to the limit of 20 requests per batch. This means that if your code exceeds this limit, the SDK will split the requests into separate batches behind the scenes, ensuring that each batch complies with the limitation. You no longer need to manually implement logic to handle this batching limit, which makes your code cleaner and easier to manage.
 
 

--- a/concepts/sdks/batch-requests.md
+++ b/concepts/sdks/batch-requests.md
@@ -76,3 +76,9 @@ This example shows how to send multiple requests in a batch that are dependent o
 :::code language="typescript" source="./snippets/typescript/src/snippets/batchRequests.ts" id="DependentBatchSnippet":::
 
 ---
+
+> [!NOTE]
+> ## Automatic batching for request limits
+> The Microsoft Graph SDK automatically handles batching requests with respect to the limit of 20 requests per batch. This means that if your code exceeds this limit, the SDK will split the requests into separate batches behind the scenes, ensuring that each batch complies with the limitation. You no longer need to manually implement logic to handle this batching limit, making your code cleaner and easier to manage.
+
+


### PR DESCRIPTION
Added information about Microsoft Graph SDK handles 20 batch requests limit automatically behind the scene. We do not need to manage this via code.


