### PR TITLE
Fix Graph API URL for SPE lock and unlock endpoints in documentation

### DIFF
--- a/api-reference/beta/api/filestoragecontainer-lock.md
+++ b/api-reference/beta/api/filestoragecontainer-lock.md
@@ -30,7 +30,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 ## HTTP request
 
 ``` http
-POST /storageContainers/{containerId}/lock
+POST /storage/fileStorage/containers/{containerId}/lock
 ```
 
 ## Request body
@@ -57,7 +57,7 @@ If successful, this method returns a `204 No Content` response code.
 The following example shows how to lock a fileStorageContainer.
 
 ``` http
-POST https://graph.microsoft.com/beta/storageContainers/b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z/lock
+POST https://graph.microsoft.com/beta/storage/fileStorage/containers/b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z/lock
 
 {
     "lockState": "lockedReadOnly"

--- a/api-reference/beta/api/filestoragecontainer-unlock.md
+++ b/api-reference/beta/api/filestoragecontainer-unlock.md
@@ -29,7 +29,7 @@ When delegated permissions are used, only members in the `owner` role can call t
 ## HTTP request
 
 ``` http
-POST /storageContainers/{containerId}/unlock
+POST /storage/fileStorage/containers/{containerId}/unlock
 ```
 
 ## Request headers
@@ -51,7 +51,7 @@ If successful, this method returns a `204 No Content` response code.
 The following example shows how to unlock a **fileStorageContainer**.
 
 ``` http
-POST https://graph.microsoft.com/beta/storageContainers/b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z/unlock
+POST https://graph.microsoft.com/beta/storage/fileStorage/containers/b!ISJs1WRro0y0EWgkUYcktDa0mE8zSlFEqFzqRn70Zwp1CEtDEBZgQICPkRbil_5Z/unlock
 ```
 
 ### Response


### PR DESCRIPTION
The URL for the SPE lock and unlock endpoints has been fixed to the right ones in the Graph API documentation.





---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
