### PR TITLE
Update group-list.md

### DIFF
--- a/api-reference/beta/api/group-list.md
+++ b/api-reference/beta/api/group-list.md
@@ -306,7 +306,6 @@ Content-type: application/json
 
 {
    "@odata.context":"https://graph.microsoft.com/beta/$metadata#groups(id,displayName)",
-   "@odata.count":2,
    "value":[
       {
          "id":"11111111-2222-3333-4444-555555555555",

--- a/api-reference/beta/api/group-list.md
+++ b/api-reference/beta/api/group-list.md
@@ -239,14 +239,11 @@ Content-type: application/json
 }
 ```
 
-### Example 2: Get a filtered list of groups including the count of returned objects
+### Example 2: Get a filtered list of groups 
+
+This request that filters against the **hasMembersWithLicenseErrors** property doesn't support retrieving the count of returned objects.
 
 #### Request
-
-The following example shows a request. This request requires the **ConsistencyLevel** header set to `eventual` because `$count` is in the request. For more information about the use of **ConsistencyLevel** and `$count`, see [Advanced query capabilities on directory objects](/graph/aad-advanced-queries).
-
-> **Note:** The `$count` and `$search` query parameters are currently not available in Azure AD B2C tenants.
-
 
 # [HTTP](#tab/http)
 <!-- {
@@ -255,8 +252,7 @@ The following example shows a request. This request requires the **ConsistencyLe
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/groups?$count=true&$filter=hasMembersWithLicenseErrors+eq+true&$select=id,displayName
-ConsistencyLevel: eventual
+GET https://graph.microsoft.com/beta/groups?$filter=hasMembersWithLicenseErrors+eq+true&$select=id,displayName
 ```
 
 # [C#](#tab/csharp)

--- a/api-reference/v1.0/api/group-list.md
+++ b/api-reference/v1.0/api/group-list.md
@@ -229,11 +229,9 @@ Content-type: application/json
 }
 ```
 
-### Example 2: Get a filtered list of groups including the count of returned objects
+### Example 2: Get a filtered list of groups
 
-The following example shows a request. This request requires the **ConsistencyLevel** header set to `eventual` because `$count` is in the request. For more information about the use of **ConsistencyLevel** and `$count`, see [Advanced query capabilities on directory objects](/graph/aad-advanced-queries).
-
-> **Note:** The `$count` and `$search` query parameters are currently not available in Azure AD B2C tenants.
+This request that filters against the **hasMembersWithLicenseErrors** property doesn't support retrieving the count of returned objects.
 
 #### Request
 
@@ -245,8 +243,7 @@ The following example shows a request. This request requires the **ConsistencyLe
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/groups?$count=true&$filter=hasMembersWithLicenseErrors+eq+true&$select=id,displayName
-
+GET https://graph.microsoft.com/v1.0/groups?$filter=hasMembersWithLicenseErrors+eq+true&$select=id,displayName
 ```
 
 # [C#](#tab/csharp)
@@ -300,7 +297,6 @@ Content-type: application/json
 
 {
    "@odata.context":"https://graph.microsoft.com/v1.0/$metadata#groups(id,displayName)",
-   "@odata.count":2,
    "value":[
       {
          "id":"11111111-2222-3333-4444-555555555555",

--- a/api-reference/v1.0/api/group-list.md
+++ b/api-reference/v1.0/api/group-list.md
@@ -246,7 +246,7 @@ The following example shows a request. This request requires the **ConsistencyLe
 
 ```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/groups?$count=true&$filter=hasMembersWithLicenseErrors+eq+true&$select=id,displayName
-ConsistencyLevel: eventual
+
 ```
 
 # [C#](#tab/csharp)


### PR DESCRIPTION
Executing this example 2 with "ConsistencyLevel - eventual" it fails.

Bad Request - 400 
        "code": "Request_UnsupportedQuery",
        "message": "Unsupported or invalid query filter clause specified for property 'hasMembersWithLicenseErrors' of resource 'Group'.",

It will work without the ConsistencyLevel.