### PR TITLE
Update throttling-education-rostering-apis.md

### DIFF
--- a/includes/throttling-education-rostering-apis.md
+++ b/includes/throttling-education-rostering-apis.md
@@ -9,7 +9,7 @@ ms.topic: include
 
 | Request type | Limit per app for all tenants | Limit per app per tenant |
 | ------------ | ----------------------------- | ------------------------ |
-| Any | 400000 requests per 20 seconds | 35000 requests per 10 seconds |
+| Any | 400,000 requests per 20 seconds | 35,000 requests per 10 seconds |
 
 The preceding limits apply to the following resources:  
 


### PR DESCRIPTION
Added thousands separators for easier readability

There are other places on the page where this information appears that already make use of thousands separators. This change brings this information into uniformity with the rest.


---
> [!NOTE]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Your PR won't be reviewed until you add this label.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
