### PR TITLE
Fix python FileAttachment example content_bytes b64 padding

### DIFF
--- a/api-reference/v1.0/includes/snippets/python/create-file-attachment-from-message-v1-python-snippets.md
+++ b/api-reference/v1.0/includes/snippets/python/create-file-attachment-from-message-v1-python-snippets.md
@@ -11,7 +11,7 @@ from msgraph.generated.models.file_attachment import FileAttachment
 request_body = FileAttachment(
 	odata_type = "#microsoft.graph.fileAttachment",
 	name = "smile",
-	content_bytes = base64.urlsafe_b64decode("R0lGODdhEAYEAA7"),
+	content_bytes = base64.urlsafe_b64decode("R0lGODdhEAYEAA7="),
 )
 
 result = await graph_client.me.messages.by_message_id('message-id').attachments.post(request_body)


### PR DESCRIPTION
It seems that the python example content_bytes for FileAttachment is missing the expected b64 padding.

```py
In [2]: content_bytes = base64.urlsafe_b64decode("R0lGODdhEAYEAA7")
---------------------------------------------------------------------------
Error                                     Traceback (most recent call last)
Cell In[2], line 1
----> 1 content_bytes = base64.urlsafe_b64decode("R0lGODdhEAYEAA7")

File ~/.pyenv/versions/3.12.7/lib/python3.12/base64.py:134, in urlsafe_b64decode(s)
    132 s = _bytes_from_decode_data(s)
    133 s = s.translate(_urlsafe_decode_translation)
--> 134 return b64decode(s)

File ~/.pyenv/versions/3.12.7/lib/python3.12/base64.py:88, in b64decode(s, altchars, validate)
     86     assert len(altchars) == 2, repr(altchars)
     87     s = s.translate(bytes.maketrans(altchars, b'+/'))
---> 88 return binascii.a2b_base64(s, strict_mode=validate)

Error: Incorrect padding

In [3]: content_bytes = base64.urlsafe_b64decode("R0lGODdhEAYEAA7=")

In [4]: content_bytes
Out[4]: b'GIF87a\x10\x06\x04\x00\x0e'
```

This can be easily fixed by adding the expected padding as shown.

This documentation is a little confusing as there are some SDKs where the b64 encoding has to be done explicitly, fixing this into a working examples helps to communicate that `content_bytes` expects raw data (not base64 encoded).

Hopefully there might be other additional steps that can be taken to communicate that as well. (e.g. comments, explicit mentions in the text).