### PR TITLE
Reverting Granular Permission Publication for Lifecycle Workflows until ready for customer consumption.

### DIFF
--- a/api-reference/beta/includes/permissions/identitygovernance-customtaskextension-delete-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-customtaskextension-delete-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-customtaskextension-get-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-customtaskextension-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.CustomTaskExtensions|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.CustomTaskExtensions|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.CustomTaskExtensions|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.CustomTaskExtensions|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-customtaskextension-update-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-customtaskextension-update-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-deleteditemcontainer-delete-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-deleteditemcontainer-delete-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-deleteditemcontainer-get-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-deleteditemcontainer-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-insights-toptasksprocessedsummary-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-insights-toptasksprocessedsummary-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Not supported.|Not supported.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-insights-topworkflowsprocessedsummary-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-insights-topworkflowsprocessedsummary-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Not supported.|Not supported.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-insights-workflowsprocessedbycategory-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-insights-workflowsprocessedbycategory-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Not supported.|Not supported.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-insights-workflowsprocessedsummary-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-insights-workflowsprocessedsummary-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Not supported.|Not supported.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-customtaskextensions-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-customtaskextensions-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.CustomTaskExtensions|LifecycleWorkflows.CreateWorkflows, LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.CustomTaskExtensions|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.CustomTaskExtensions|LifecycleWorkflows.CreateWorkflows, LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.CustomTaskExtensions|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-deleteditems-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-deleteditems-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-workflows-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-workflows-permissions.md
@@ -6,7 +6,6 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadBasic.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.Read.Workflows, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadBasic.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.Read.Workflows, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
-
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|

--- a/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-post-customtaskextensions-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-post-customtaskextensions-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-post-workflows-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-lifecycleworkflowscontainer-post-workflows-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.CreateWorkflows|LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.CreateWorkflows|LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-run-get-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-run-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-run-list-taskprocessingresults-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-run-list-taskprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-run-list-userprocessingresults-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-run-list-userprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-run-summary-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-run-summary-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-task-get-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-task-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-task-update-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-task-update-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-taskreport-list-taskprocessingresults-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-taskreport-list-taskprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-userprocessingresult-get-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-userprocessingresult-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-userprocessingresult-list-taskprocessingresults-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-userprocessingresult-list-taskprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-userprocessingresult-summary-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-userprocessingresult-summary-permissions.md
@@ -1,5 +1,5 @@
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-activate-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-activate-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Activate|LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Activate|LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-createnewversion-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-createnewversion-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-delete-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-delete-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-get-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-list-runs-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-list-runs-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-list-task-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-list-task-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-list-taskreports-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-list-taskreports-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-list-userprocessingresults-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-list-userprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-list-versions-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-list-versions-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-restore-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-restore-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflow-update-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflow-update-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflowversion-get-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflowversion-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/beta/includes/permissions/identitygovernance-workflowversion-list-tasks-permissions.md
+++ b/api-reference/beta/includes/permissions/identitygovernance-workflowversion-list-tasks-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-customtaskextension-delete-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-customtaskextension-delete-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-customtaskextension-get-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-customtaskextension-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.CustomTaskExtensions|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.CustomTaskExtensions|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.CustomTaskExtensions|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.CustomTaskExtensions|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-customtaskextension-update-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-customtaskextension-update-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-deleteditemcontainer-delete-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-deleteditemcontainer-delete-permissions.md
@@ -6,7 +6,6 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
-
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|

--- a/api-reference/v1.0/includes/permissions/identitygovernance-deleteditemcontainer-get-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-deleteditemcontainer-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-insights-toptasksprocessedsummary-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-insights-toptasksprocessedsummary-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Not supported.|Not supported.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-insights-topworkflowsprocessedsummary-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-insights-topworkflowsprocessedsummary-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Not supported.|Not supported.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-insights-workflowsprocessedbycategory-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-insights-workflowsprocessedbycategory-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Not supported.|Not supported.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-insights-workflowsprocessedsummary-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-insights-workflowsprocessedsummary-permissions.md
@@ -6,7 +6,6 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permission|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|Not supported.|Not supported.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|Not supported.|Not supported.|
-
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|

--- a/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-customtaskextensions-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-customtaskextensions-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.CustomTaskExtensions|LifecycleWorkflows.CreateWorkflows, LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.CustomTaskExtensions|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.CustomTaskExtensions|LifecycleWorkflows.CreateWorkflows, LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.CustomTaskExtensions|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-deleteditems-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-deleteditems-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-workflows-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-list-workflows-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadBasic.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.Read.Workflows, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadBasic.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.Read.Workflows, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-post-customtaskextensions-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-post-customtaskextensions-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.CustomTaskExtensions|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-post-workflows-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-lifecycleworkflowscontainer-post-workflows-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.CreateWorkflows|LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.CreateWorkflows|LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-run-get-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-run-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-run-list-taskprocessingresults-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-run-list-taskprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-run-list-userprocessingresults-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-run-list-userprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-run-summary-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-run-summary-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-task-get-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-task-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-task-update-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-task-update-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-taskreport-list-taskprocessingresults-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-taskreport-list-taskprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-userprocessingresult-get-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-userprocessingresult-get-permissions.md
@@ -6,7 +6,6 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
-
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|

--- a/api-reference/v1.0/includes/permissions/identitygovernance-userprocessingresult-list-taskprocessingresults-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-userprocessingresult-list-taskprocessingresults-permissions.md
@@ -6,7 +6,6 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
-
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|

--- a/api-reference/v1.0/includes/permissions/identitygovernance-userprocessingresult-summary-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-userprocessingresult-summary-permissions.md
@@ -1,5 +1,5 @@
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-activate-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-activate-permissions.md
@@ -6,7 +6,6 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Activate|LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Activate|LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
-
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-createnewversion-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-createnewversion-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-delete-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-delete-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-get-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-runs-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-runs-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-task-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-task-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-taskreports-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-taskreports-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-userprocessingresults-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-userprocessingresults-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadReports.All|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-versions-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-list-versions-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-restore-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-restore-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflow-update-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflow-update-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Delegated (work or school account)|LifecycleWorkflows.ReadWrite.All|Not available.|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.ReadWrite.Workflows|LifecycleWorkflows.ReadWrite.All|
+|Application|LifecycleWorkflows.ReadWrite.All|Not available.|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflowversion-get-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflowversion-get-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 

--- a/api-reference/v1.0/includes/permissions/identitygovernance-workflowversion-list-tasks-permissions.md
+++ b/api-reference/v1.0/includes/permissions/identitygovernance-workflowversion-list-tasks-permissions.md
@@ -6,7 +6,7 @@ ms.localizationpriority: medium
 
 |Permission type|Least privileged permissions|Higher privileged permissions|
 |:---|:---|:---|
-|Delegated (work or school account)|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Delegated (work or school account)|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|Not supported.|
-|Application|LifecycleWorkflows.Read.Workflows|LifecycleWorkflows.Read.All, LifecycleWorkflows.ReadWrite.All, LifecycleWorkflows.ReadWrite.Workflows|
+|Application|LifecycleWorkflows.Read.All|LifecycleWorkflows.ReadWrite.All|
 


### PR DESCRIPTION
> [!IMPORTANT]
> Required for API changes:
> - Link to API.md file: *ADD LINK HERE*
> - Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl):  *ADD LINK HERE*

---
Add other supporting information, such as a description of the PR changes:

Accidently configured our new granular permissions for LCW to a state where the permissions would be provisioned, but we did not intend it to be published until we were ready to unhide the permissions in the portal. This PR reverts all the new granular permission changes back to our original 2 permissions LifecycleWorkflows.Read.All and LifecycleWorkflows.ReadWrite.All and also fixed a permission tables that were incorrect.

We tried to reconfigure the permission to hide them and refresh the docs here: https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/11299346. However it did not do the reversion, hence the PR made here.

In general, list and reads have both LifecycleWorkflows.Read.All and LifecycleWorkflows.ReadWrite.All. Updates, delete, remove will only use LifecycleWorkflows.ReadWrite.All

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/707655/Minimum-requirements-for-content-review) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
