### PR TITLE
Cover application permissions in group lookup

### DIFF
--- a/concepts/permissions-overview.md
+++ b/concepts/permissions-overview.md
@@ -115,8 +115,9 @@ This principle is applied to all relationships that are of [directoryObject](/gr
 For example, a group can have users, groups, applications, service principals, devices, and contacts as members. An app is granted the *GroupMember.Read.All* least privileged permission to [List group members](/graph/api/group-list-members). In the response object, only the **id** and **@odata.type** properties are populated for all the members that are returned. The other properties are indicated as `null`. For this API:
 - To read the basic properties of a group's members that are users, the app needs at least the *User.ReadBasic.All* permission.
 - To read the basic properties of a group's members that are groups, the app needs at least the *GroupMember.Read.All* permission.
-- To read the basic properties of a group's members that are devices, the app needs at least the *Device.Read.All* permission, and so on.
-- However, as an alternative to the individual resource-level permissions, the app can be assigned at least the *Directory.Read.All* permission to read *all properties for all member types*.
+- To read the basic properties of a group's members that are devices, the app needs at least the *Device.Read.All* permission.
+- To read the basic properties of a group's members that are service principals, the app needs at least the *Application.Read.All* permission.
+- As per the principle of least privilege, you should prefer using the above permissions as appropriate for your application. However, as an alternative to the individual resource-level permissions, the app can be assigned the *Directory.Read.All* permission to read *all properties for all member types*.
 
 ### Example
 

--- a/concepts/permissions-overview.md
+++ b/concepts/permissions-overview.md
@@ -112,12 +112,12 @@ Container objects such as groups support members of various types, for example u
 
 This principle is applied to all relationships that are of [directoryObject](/graph/api/resources/directoryobject) type. Examples include `/groups/{id}/members`, `/users/{id}/memberOf`, and `me/ownedObjects`.
 
-For example, a group can have users, groups, applications, service principals, devices, and contacts as members. An app is granted the *GroupMember.Read.All* least privileged permission to [List group members](/graph/api/group-list-members). In the response object, only the **id** and **@odata.type** properties are populated for all the members that are returned. The other properties are indicated as `null`. For this API:
-- To read the basic properties of a group's members that are users, the app needs at least the *User.ReadBasic.All* permission.
-- To read the basic properties of a group's members that are groups, the app needs at least the *GroupMember.Read.All* permission.
-- To read the basic properties of a group's members that are devices, the app needs at least the *Device.Read.All* permission.
-- To read the basic properties of a group's members that are service principals, the app needs at least the *Application.Read.All* permission.
-- As per the principle of least privilege, you should prefer using the above permissions as appropriate for your application. However, as an alternative to the individual resource-level permissions, the app can be assigned the *Directory.Read.All* permission to read *all properties for all member types*.
+For example, a group can have users, groups, applications, service principals, devices, and contacts as members. An app is granted the *GroupMember.Read.All* least privileged permission to [List group members](/graph/api/group-list-members). In the response object, only the **id** and **@odata.type** properties are populated for all the members that are returned. The other properties are indicated as `null`. For this API, and to return data for the other object types, the app needs the following additional permissions:
+- To read the basic properties of a group's members that are users, *User.ReadBasic.All* is the least privileged permission.
+- To read the basic properties of a group's members that are groups, *GroupMember.Read.All* is the least privileged permission.
+- To read the basic properties of a group's members that are devices, *Device.Read.All* is the least privileged permission.
+- To read the basic properties of a group's members that are service principals, *Application.Read.All* is the least privileged permission.
+- As per the principle of least privilege, you should prefer using the preceding permissions as appropriate for your application. However, as an alternative to the individual resource-level permissions, the app can be assigned the *Directory.Read.All* permission to read *all properties for all member types*.
 
 ### Example
 

--- a/concepts/permissions-overview.md
+++ b/concepts/permissions-overview.md
@@ -112,7 +112,7 @@ Container objects such as groups support members of various types, for example u
 
 This principle is applied to all relationships that are of [directoryObject](/graph/api/resources/directoryobject) type. Examples include `/groups/{id}/members`, `/users/{id}/memberOf`, and `me/ownedObjects`.
 
-For example, a group can have users, groups, applications, service principals, devices, and contacts as members. An app is granted the *GroupMember.Read.All* least privileged permission to [List group members](/graph/api/group-list-members). In the response object, only the **id** and **@odata.type** properties are populated for all the members that are returned. The other properties are indicated as `null`. For this API, and to return data for the other object types, the app needs the following additional permissions:
+For example, a group can have users, groups, applications, service principals, devices, and contacts as members. An app is granted the *GroupMember.Read.All* least privileged permission to [List group members](/graph/api/group-list-members). In the response object, only the **id** and **@odata.type** properties are populated for all the members that are returned. The other properties are indicated as `null`. For this API, and to return more information for the group's members, the app needs the following additional permissions:
 - To read the basic properties of a group's members that are users, *User.ReadBasic.All* is the least privileged permission.
 - To read the basic properties of a group's members that are groups, *GroupMember.Read.All* is the least privileged permission.
 - To read the basic properties of a group's members that are devices, *Device.Read.All* is the least privileged permission.


### PR DESCRIPTION
This brings the public docs in line with some internal conversations about group lookup permissions, and emphasizes using narrower permissions when appropriate.