### PR TITLE
Correct admin roles for profile photo edits.

### DIFF
--- a/api-reference/beta/api/profilephoto-delete.md
+++ b/api-reference/beta/api/profilephoto-delete.md
@@ -43,7 +43,7 @@ The following tables show the least privileged permission or permissions require
 |Application      |    ProfilePhoto.ReadWrite.All           | Group.ReadWrite.All |
 
 > [!NOTE]
-> - Global admins, User admins and People admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
+> - Global admins, User admins, and People admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
 
 ## HTTP request
 

--- a/api-reference/beta/api/profilephoto-delete.md
+++ b/api-reference/beta/api/profilephoto-delete.md
@@ -43,7 +43,7 @@ The following tables show the least privileged permission or permissions require
 |Application      |    ProfilePhoto.ReadWrite.All           | Group.ReadWrite.All |
 
 > [!NOTE]
-> - Global and user admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
+> - Global admins, User admins and People admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
 
 ## HTTP request
 

--- a/api-reference/beta/api/profilephoto-update.md
+++ b/api-reference/beta/api/profilephoto-update.md
@@ -61,7 +61,7 @@ You can use either PATCH or PUT for this operation.
 > [!NOTE]
 >
 > - Permissions marked with * are supported only for backward compatibility. Please update your solutions to use an alternative permission and avoid using these permissions going forward.
-> - Users with admin roles such as User admins can update the photo of any user in the organization by using delegated permissions. This operation is also supported with application permissions. Updating the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permission. Updating the photo of the signed-in user only requires *User.ReadWrite* permission.
+> - Users with admin roles such as User admins, Global admins or People admins can update the photo of any user in the organization by using delegated permissions. This operation is also supported with application permissions. Updating the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permission. Updating the photo of the signed-in user only requires *User.ReadWrite* permission.
 > - Updating a user's photo using the Microsoft Graph API is currently not supported in Azure AD B2C tenants.
 
 ## HTTP request

--- a/api-reference/beta/api/profilephoto-update.md
+++ b/api-reference/beta/api/profilephoto-update.md
@@ -61,7 +61,7 @@ You can use either PATCH or PUT for this operation.
 > [!NOTE]
 >
 > - Permissions marked with * are supported only for backward compatibility. Please update your solutions to use an alternative permission and avoid using these permissions going forward.
-> - Users with admin roles such as User admins, Global admins or People admins can update the photo of any user in the organization by using delegated permissions. This operation is also supported with application permissions. Updating the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permission. Updating the photo of the signed-in user only requires *User.ReadWrite* permission.
+> - Users with admin roles such as User admins, Global admins, or People admins can update the photo of any user in the organization by using delegated permissions. This operation is also supported with application permissions. Updating the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permission. Updating the photo of the signed-in user only requires *User.ReadWrite* permission.
 > - Updating a user's photo using the Microsoft Graph API is currently not supported in Azure AD B2C tenants.
 
 ## HTTP request

--- a/api-reference/v1.0/api/profilephoto-delete.md
+++ b/api-reference/v1.0/api/profilephoto-delete.md
@@ -44,7 +44,7 @@ The following tables show the least privileged permission or permissions require
 |Application      |    ProfilePhoto.ReadWrite.All           | Group.ReadWrite.All |
 
 > [!NOTE]
-> - Global and user admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
+> - Global admins, user admins and people admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/profilephoto-delete.md
+++ b/api-reference/v1.0/api/profilephoto-delete.md
@@ -44,7 +44,7 @@ The following tables show the least privileged permission or permissions require
 |Application      |    ProfilePhoto.ReadWrite.All           | Group.ReadWrite.All |
 
 > [!NOTE]
-> - Global admins, user admins and people admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
+> - Global admins, User admins and People admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/profilephoto-delete.md
+++ b/api-reference/v1.0/api/profilephoto-delete.md
@@ -44,7 +44,7 @@ The following tables show the least privileged permission or permissions require
 |Application      |    ProfilePhoto.ReadWrite.All           | Group.ReadWrite.All |
 
 > [!NOTE]
-> - Global admins, User admins and People admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
+> - Global admins, User admins, and People admins can delete the photo of any user in the organization using delegated permissions. This operation also supports application permissions. Deleting the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permissions. Deleting the photo of the signed-in user only requires *User.ReadWrite* permissions.
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -60,7 +60,7 @@ The following tables show the least privileged permission or permissions require
 
 > [!NOTE]
 >
-> - Users with admin roles such as User admins can update the photo of any user in the organization by using delegated permissions. This operation is also supported with application permissions. Updating the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permission. Updating the photo of the signed-in user only requires *User.ReadWrite* permission.
+> - Users with admin roles such as User admins, Global admins or People admins can update the photo of any user in the organization by using delegated permissions. This operation is also supported with application permissions. Updating the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permission. Updating the photo of the signed-in user only requires *User.ReadWrite* permission.
 > - Updating a user's photo using the Microsoft Graph API is currently not supported in Azure AD B2C tenants.
 
 ## HTTP request

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -60,7 +60,7 @@ The following tables show the least privileged permission or permissions require
 
 > [!NOTE]
 >
-> - Users with admin roles such as User admins, Global admins or People admins can update the photo of any user in the organization by using delegated permissions. This operation is also supported with application permissions. Updating the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permission. Updating the photo of the signed-in user only requires *User.ReadWrite* permission.
+> - Users with admin roles such as User admins, Global admins, or People admins can update the photo of any user in the organization by using delegated permissions. This operation is also supported with application permissions. Updating the photo of any user in the organization requires *ProfilePhoto.ReadWrite.All* or *User.ReadWrite.All* permission. Updating the photo of the signed-in user only requires *User.ReadWrite* permission.
 > - Updating a user's photo using the Microsoft Graph API is currently not supported in Azure AD B2C tenants.
 
 ## HTTP request

--- a/concepts/profilephoto-configure-settings.md
+++ b/concepts/profilephoto-configure-settings.md
@@ -111,7 +111,7 @@ Content-Type: application/json
 ```
 ### Configure adminstrator support for profile photo updates
 
-The following example shows how to configure the Global Administrator, User Administrator and People Administrator roles to change profile photo update settings in your organization.
+The following example shows how to configure the Global Administrator, User Administrator, and People Administrator roles to change profile photo update settings in your organization.
 
 ```http
 PATCH https://graph.microsoft.com/beta/admin/people/photoupdatesettings

--- a/concepts/profilephoto-configure-settings.md
+++ b/concepts/profilephoto-configure-settings.md
@@ -49,7 +49,7 @@ Content-Type: application/json
 
 {
     "source": "cloud",
-    "allowedRoles": {}
+    "allowedRoles": []
 }
 ```
 

--- a/concepts/profilephoto-configure-settings.md
+++ b/concepts/profilephoto-configure-settings.md
@@ -111,7 +111,7 @@ Content-Type: application/json
 ```
 ### Configure adminstrator support for profile photo updates
 
-The following example shows how to configure the Global Administrator and User Administrator roles to change profile photo update settings in your organization.
+The following example shows how to configure the Global Administrator, User Administrator and People Administrator roles to change profile photo update settings in your organization.
 
 ```http
 PATCH https://graph.microsoft.com/beta/admin/people/photoupdatesettings
@@ -119,7 +119,7 @@ Content-Type: application/json
 
 {
     "source": "cloud",
-    "allowedRoles": ["62e90394-69f5-4237-9190-012177145e10", "fe930be7-5e62-47db-91af-98c3a49a38b1"]
+    "allowedRoles": ["62e90394-69f5-4237-9190-012177145e10", "fe930be7-5e62-47db-91af-98c3a49a38b1", "024906de-61e5-49c8-8572-40335f1e0e10"]
 }
 ```
 


### PR DESCRIPTION
New role (People Administrator) was introduced in Entra for profile photo edits, updating the docs with it. 
Relevant PR: https://msazure.visualstudio.com/One/_git/AD-MSODS-Core/pullrequest/11640921?path=%2Fsrc%2Fdev%2Fidentity%2Fauthz%2FRoleDefinitions%2FroleDefinitions%2FGlobalAdministrator%2FGlobalAdministrator.json
Following the process in https://eng.ms/docs/microsoft-security/identity/entra-developer-application-platform/app-vertical/aad-first-party-apps/identity-platform-and-access-management/role-based-access-control/ship-new-role.

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/707655/Minimum-requirements-for-content-review) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://dev.azure.com/msazure/One/_wiki/wikis/Microsoft%20Graph%20Partners/614263/Content-workflow).

</details>
