### PR TITLE
approvalitem-cancel: clarify detail on who can use api

### DIFF
--- a/api-reference/beta/api/approvalitem-cancel.md
+++ b/api-reference/beta/api/approvalitem-cancel.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Cancel the [approval item](../resources/approvalitem.md). The owner of the approval can trigger this endpoint.
+Cancel the [approval item](../resources/approvalitem.md). The owner of the approval is the only user who can trigger this endpoint.
 
 [!INCLUDE [national-cloud-support](../../includes/global-only.md)]
 


### PR DESCRIPTION
The current documentation makes clear that the owner can cancel, but does not make clear that other users (including approval admins in the environment) cannot. This rewords to clarify.
