### PR TITLE
Add corresponding value to allowInvitesFrom

### DIFF
--- a/api-reference/v1.0/resources/authorizationpolicy.md
+++ b/api-reference/v1.0/resources/authorizationpolicy.md
@@ -39,12 +39,12 @@ Represents a policy that can control Microsoft Entra authorization settings. It'
 
 ### allowInvitesFrom values
 
-|Member|Description|
-|:---|:---|
-|none|Prevent everyone, including admins, from inviting guests. Default setting for US Government.|
-|adminsAndGuestInviters|Allow members of *Global Administrator*, *User Administrator*, and *Guest Inviter* roles to invite guests.|
-|adminsGuestInvitersAndAllMembers|Allow the above admin roles and all other User role members to invite guests.|
-|everyone|Allow everyone in the organization, including guests, to invite guests. The default setting for all cloud environments except US Government.|
+|Member|Value|Description|
+|:---|:---|:---|
+|none|0|Prevent everyone, including admins, from inviting guests. Default setting for US Government.|
+|adminsAndGuestInviters|1|Allow members of *Global Administrator*, *User Administrator*, and *Guest Inviter* roles to invite guests.|
+|adminsGuestInvitersAndAllMembers|2|Allow the above admin roles and all other User role members to invite guests.|
+|everyone|3|Allow everyone in the organization, including guests, to invite guests. The default setting for all cloud environments except US Government.|
 
 ## Relationships
 


### PR DESCRIPTION
This is not related to API changes.

In [External collaboration settings] in Entra ID External Identities. "Guest invite settings" has 4 options. 

- Anyone in the organization can invite guest users including guests and non-admins (most inclusive)
- Member users and users assigned to specific admin roles can invite guest users including guests with member permissions
- Only users assigned to specific admin roles can invite guest users
- No one in the organization can invite guest users including admins (most restrictive)

When an admin changed this option, an audit log activity "Update authorization policy" is generated. The audit log shows a property "AllowInvitesFrom" was changed, for example, from 2 to 1. However, there is no doc that explains which number corresponds to which option.

![image](https://github.com/user-attachments/assets/17eb9ac8-c63d-4b6b-8d2c-412e6a83ec88)

This is why I am adding the corresponding numbers to each option in this PR.

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
