### PR TITLE
Update preauthorizedapplication.md

### DIFF
--- a/api-reference/v1.0/resources/preauthorizedapplication.md
+++ b/api-reference/v1.0/resources/preauthorizedapplication.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph
 
 Lists the client applications that are preauthorized with the specified permissions to access this application's APIs. Users aren't required to consent to any preauthorized application (for the permissions specified). However, any other permissions not listed in preAuthorizedApplications (requested through incremental consent for example) require user consent.
 
-In some rare cases, an identifier listed in the `delegatedPermissionIds` property may actually identify an [app role](approle.md) (from the service principal's `appRoles` property), indicating that the client application identified by the `appId` property has been preauthorized for that app role.
+The app role technically is modelled as an app-only scope.  Pre-authorization of app-only scopes to clients is not currently supported. Validation checks are performed at runtime to ensure that the current PermissionIds are of type DelegatedPermissions. In scenarios where customers want to avoid the Consent experience associated with app roles, they should grant AppRoles to a client app programmatically. Read more about Grant app role assignemnt to service prin Grant an appRoleAssignment to a service principal [approle](https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/v1.0/api/serviceprincipal-post-approleassignments.md).
 
 ## Properties
 


### PR DESCRIPTION
The following public document states that "In some rare cases, an identifier listed in the delegatedPermissionIds property may actually identify an app role (from the service principal's appRoles property), indicating that the client application identified by the appId property has been preauthorized for that app role." https://learn.microsoft.com/en-us/graph/api/resources/preauthorizedapplication?view=graph-rest-1.0

It is recommended that the following statement be added to ensure that customers don't think we support preauthorization of app roles to clients. The app role technically is modelled as an app-only scope.  Pre-authorization of app-only scopes to clients is not currently supported. Validation checks are performed at runtime to ensure that the current PermissionIds are of type DelegatedPermissions. In scenarios where customers want to avoid the Consent experience associated with app roles, they should grant AppRoles to a client app programmatically. Reference: Grant an appRoleAssignment to a service principal - Microsoft Graph v1.0 | Microsoft Learn

> [!IMPORTANT]
> Required for API changes:
> - Link to API.md file: *ADD LINK HERE*
> - Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl):  *ADD LINK HERE*

---
Add other supporting information, such as a description of the PR changes:

*ADD INFORMATION HERE*

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
