### PR TITLE
Add Cautionary note for searching limitation with OneDrive Search API

### DIFF
--- a/api-reference/v1.0/api/driveitem-search.md
+++ b/api-reference/v1.0/api/driveitem-search.md
@@ -13,6 +13,8 @@ Namespace: microsoft.graph
 
 Search the hierarchy of items for items matching a query.
 You can search within a folder hierarchy, a whole drive, or files shared with the current user.
+>**Note:** If a file does not appear in search results, manually searching for it in OneDrive UI may trigger indexing and help resolve the issue.
+
 
 ## Permissions
 

--- a/api-reference/v1.0/api/driveitem-search.md
+++ b/api-reference/v1.0/api/driveitem-search.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph
 Search the hierarchy of items for items matching a query.
 You can search within a folder hierarchy, a whole drive, or files shared with the current user.
 >[!Note] 
-> If a file doesn't appear in search results, manually searching for it in OneDrive UI may trigger indexing and help resolve the issue.
+>If a file doesn't appear in search results, manually searching for it in OneDrive UI may trigger indexing and help resolve the issue.
 
 
 ## Permissions

--- a/api-reference/v1.0/api/driveitem-search.md
+++ b/api-reference/v1.0/api/driveitem-search.md
@@ -13,7 +13,8 @@ Namespace: microsoft.graph
 
 Search the hierarchy of items for items matching a query.
 You can search within a folder hierarchy, a whole drive, or files shared with the current user.
->**Note:** If a file does not appear in search results, manually searching for it in OneDrive UI may trigger indexing and help resolve the issue.
+>[!Note] 
+> If a file doesn't appear in search results, manually searching for it in OneDrive UI may trigger indexing and help resolve the issue.
 
 
 ## Permissions


### PR DESCRIPTION
Adding a cautionary note in the top section regarding the issue with indexing of onedrive search api.
