### PR TITLE
Office files can be commented on in read only mode

### DIFF
--- a/api-reference/beta/resources/permission.md
+++ b/api-reference/beta/resources/permission.md
@@ -58,11 +58,11 @@ OneDrive for Business and SharePoint document libraries don't return the **inher
 
 ### Roles property values
 
-| Value           | Description                                                                    |
-|:----------------|:-------------------------------------------------------------------------------|
-| read            | Provides the ability to read the metadata and contents of the item.            |
-| write           | Provides the ability to read and modify the metadata and contents of the item. |
-| owner           | For SharePoint and OneDrive for Business this represents the owner role.       |
+| Value           | Description                                                                        |
+|:----------------|:-----------------------------------------------------------------------------------|
+| read            | Provides the ability to read the metadata and commment on the contents of the item.|
+| write           | Provides the ability to read and modify the metadata and contents of the item.     |
+| owner           | For SharePoint and OneDrive for Business this represents the owner role.           |
 
 The permission resource uses _facets_ to provide information about the kind of permission represented by the resource.
 


### PR DESCRIPTION
 
This pull request elaborates on the ability to comment on office files in read only mode. Today, read only mode is not limited to viewing only it also including commenting.