### PR TITLE
Update unifiedroledefinition-get.md

### DIFF
--- a/api-reference/beta/api/unifiedroledefinition-get.md
+++ b/api-reference/beta/api/unifiedroledefinition-get.md
@@ -22,7 +22,7 @@ The following RBAC providers are currently supported:
 - device management (Intune)
 - directory (Microsoft Entra directory roles)
 - entitlement management (Microsoft Entra entitlement management)
-- Exchange Online
+- Exchange Online (Except China operated by 21Vianet)
 
 [!INCLUDE [national-cloud-support](../../includes/all-clouds.md)]
 


### PR DESCRIPTION
Based on customer escalation, our team realized that Exchange Online unified RBAC functionality is not working on this cloud, aligning the documentation.
