### PR TITLE
Update driveitem-get-content-format.md

### DIFF
--- a/api-reference/v1.0/api/driveitem-get-content-format.md
+++ b/api-reference/v1.0/api/driveitem-get-content-format.md
@@ -26,7 +26,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 [!INCLUDE [permissions-table](../includes/permissions/driveitem-get-content-format-permissions.md)]
 
 > [!NOTE]
-> * The maximum size limit for files to use format conversion is 2 MB.
+> The maximum size limit for files to use format conversion is 2 MB.
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/driveitem-get-content-format.md
+++ b/api-reference/v1.0/api/driveitem-get-content-format.md
@@ -25,6 +25,9 @@ Choose the permission or permissions marked as least privileged for this API. Us
 <!-- { "blockType": "permissions", "name": "driveitem_get_content_format" } -->
 [!INCLUDE [permissions-table](../includes/permissions/driveitem-get-content-format-permissions.md)]
 
+> [!NOTE]
+> * The maximum size limit for files to use format conversion is 2 MB.
+
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->


### PR DESCRIPTION
need to add a note on file size limitation per the PG (gaddanki@microsoft.com)

> [!IMPORTANT]
> Required for API changes:
> - Link to API.md file: - reference/v1.0/api/driveitem-get-content-format.md

The limit for conversion of files according to gaddanki@microsoft.com is 2 MB. Going over this results often in timeouts although sometimes it works.


