### PR TITLE
Update users-passwordprofile-permissions.md

### DIFF
--- a/api-reference/beta/includes/users-passwordprofile-permissions.md
+++ b/api-reference/beta/includes/users-passwordprofile-permissions.md
@@ -10,4 +10,4 @@ ms.topic: include
 - In delegated scenarios, the calling app must be assigned a supported permission *and* a supported Microsoft Entra role.
   - *Privileged Authentication Administrator* is the least privileged role that's allowed to update this property for *all* administrators in the tenant.
   - In general, the signed-in user must have a higher privileged administrator role as indicated in [Who can reset passwords](/graph/api/resources/users#who-can-reset-passwords).
-- In app-only scenarios, the calling app must be assigned a supported permission *and* at least the *User Administrator* [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json).
+- In app-only scenarios, the calling app must be assigned *User-PasswordProfile.ReadWrite.All* and at least *User.ReadWrite.All*.

--- a/api-reference/v1.0/includes/users-passwordprofile-permissions.md
+++ b/api-reference/v1.0/includes/users-passwordprofile-permissions.md
@@ -10,4 +10,4 @@ ms.topic: include
 - In delegated scenarios, the calling app must be assigned a supported permission *and* a supported Microsoft Entra role.
   - *Privileged Authentication Administrator* is the least privileged role that's allowed to update this property for *all* administrators in the tenant.
   - In general, the signed-in user must have a higher privileged administrator role as indicated in [Who can reset passwords](/graph/api/resources/users#who-can-reset-passwords).
-- In app-only scenarios, the calling app must be assigned a supported permission *and* at least the *User Administrator* [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json).
+- In app-only scenarios, the calling app must be assigned *User-PasswordProfile.ReadWrite.All* and at least *User.ReadWrite.All*.


### PR DESCRIPTION
In app-only scenarios, it works without Entra roles such as the User Administrator or the Password Administrator.

> [!IMPORTANT]
> Required for API changes:
> - Link to API.md file: https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/v1.0/includes/users-passwordprofile-permissions.md
> - Link to API.md file: https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/beta/includes/users-passwordprofile-permissions.md

---
Add other supporting information, such as a description of the PR changes:

*ADD INFORMATION HERE*

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
