### PR TITLE
Clarify supported OData params for Group deltas

### DIFF
--- a/api-reference/beta/api/group-delta.md
+++ b/api-reference/beta/api/group-delta.md
@@ -54,7 +54,9 @@ In subsequent requests, copy and apply the `@odata.nextLink` or `@odata.deltaLin
 This method supports optional OData query parameters to help customize the response.
 
 - You can use a `$select` query parameter as in any GET request to specify only the properties your need for best performance. The _id_ property is always returned.
-- You can use `$select=members` to get membership changes. You can additionally track other changes like ownership and more by selecting any [group relationship](../resources/group.md#relationships) of type **directoryObject collection**.
+- You can use `$select=members` to get membership changes.
+   - You can additionally track other changes like ownership and more by selecting any [group relationship](../resources/group.md#relationships) of type **directoryObject collection**.
+   - Only the _id_ property of the related resource is returned.
 - There's limited support for `$filter`:
   - The only supported `$filter` expression is for tracking changes on a specific object: `$filter=id+eq+{value}`. You can filter multiple objects. For example, `https://graph.microsoft.com/beta/groups/delta/?$filter= id eq '477e9fc6-5de7-4406-bb2a-7e5c83c9ffff' or id eq '004d6a07-fe70-4b92-add5-e6e37b8affff'`. There's a limit of 50 filtered objects.
 

--- a/api-reference/beta/api/group-delta.md
+++ b/api-reference/beta/api/group-delta.md
@@ -53,10 +53,10 @@ In subsequent requests, copy and apply the `@odata.nextLink` or `@odata.deltaLin
 
 This method supports optional OData query parameters to help customize the response.
 
-- You can use a `$select` query parameter as in any GET request to specify only the properties your need for best performance. The _id_ property is always returned.
+- You can use a `$select` query parameter as in any GET request to specify only the properties your need for best performance. The **id** property is always returned.
 - You can use `$select=members` to get membership changes.
    - You can additionally track other changes like ownership and more by selecting any [group relationship](../resources/group.md#relationships) of type **directoryObject collection**.
-   - Only the _id_ property of the related resource is returned.
+   - Only the **id** property of the related resource is returned.
 - There's limited support for `$filter`:
   - The only supported `$filter` expression is for tracking changes on a specific object: `$filter=id+eq+{value}`. You can filter multiple objects. For example, `https://graph.microsoft.com/beta/groups/delta/?$filter= id eq '477e9fc6-5de7-4406-bb2a-7e5c83c9ffff' or id eq '004d6a07-fe70-4b92-add5-e6e37b8affff'`. There's a limit of 50 filtered objects.
 

--- a/api-reference/v1.0/api/group-delta.md
+++ b/api-reference/v1.0/api/group-delta.md
@@ -52,7 +52,9 @@ In subsequent requests, copy and apply the `@odata.nextLink` or `@odata.deltaLin
 This method supports optional OData query parameters to help customize the response.
 
 - You can use a `$select` query parameter as in any GET request to specify only the properties your need for best performance. The _id_ property is always returned.
-- You can use `$select=members` to get membership changes. You can additionally track other changes like ownership and more by selecting any [group relationship](../resources/group.md#relationships) of type **directoryObject collection**.
+- You can use `$select=members` to get membership changes.
+   - You can additionally track other changes like ownership and more by selecting any [group relationship](../resources/group.md#relationships) of type **directoryObject collection**.
+   - Only the _id_ property of the related resource is returned.
 - There's limited support for `$filter`:
   - The only supported `$filter` expression is for tracking changes on a specific object: `$filter=id+eq+{value}`. You can filter multiple objects. For example, `https://graph.microsoft.com/v1.0/groups/delta/?$filter= id eq '477e9fc6-5de7-4406-bb2a-7e5c83c9ffff' or id eq '004d6a07-fe70-4b92-add5-e6e37b8affff'`. There is a limit of 50 filtered objects.
 

--- a/api-reference/v1.0/api/group-delta.md
+++ b/api-reference/v1.0/api/group-delta.md
@@ -51,10 +51,10 @@ In subsequent requests, copy and apply the `@odata.nextLink` or `@odata.deltaLin
 
 This method supports optional OData query parameters to help customize the response.
 
-- You can use a `$select` query parameter as in any GET request to specify only the properties your need for best performance. The _id_ property is always returned.
+- You can use a `$select` query parameter as in any GET request to specify only the properties your need for best performance. The **id** property is always returned.
 - You can use `$select=members` to get membership changes.
    - You can additionally track other changes like ownership and more by selecting any [group relationship](../resources/group.md#relationships) of type **directoryObject collection**.
-   - Only the _id_ property of the related resource is returned.
+   - Only the **id** property of the related resource is returned.
 - There's limited support for `$filter`:
   - The only supported `$filter` expression is for tracking changes on a specific object: `$filter=id+eq+{value}`. You can filter multiple objects. For example, `https://graph.microsoft.com/v1.0/groups/delta/?$filter= id eq '477e9fc6-5de7-4406-bb2a-7e5c83c9ffff' or id eq '004d6a07-fe70-4b92-add5-e6e37b8affff'`. There is a limit of 50 filtered objects.
 


### PR DESCRIPTION
Minor change to the Group Delta documentation to clarify that `$select=members` will only return the _id_ property. This addresses some developer confusion around which properties should be expected in the response. 
