### PR TITLE
Update channel-getallretainedmessages.md

### DIFF
--- a/api-reference/beta/api/channel-getallretainedmessages.md
+++ b/api-reference/beta/api/channel-getallretainedmessages.md
@@ -23,6 +23,9 @@ To learn more about how to use the Microsoft Teams export APIs to export content
 > [!NOTE]  
 > This API requires [Teams retention policies](/purview/create-retention-policies?tabs=teams-retention) to be configured. For more information, see [Learn about retention for Microsoft Teams](/purview/retention-policies-teams).
 
+> [!NOTE]
+> This Endpoint Doesn't Support retrieving Retained messages from Teams private channels
+
 [!INCLUDE [national-cloud-support](../../includes/all-clouds.md)]
 
 ## Permissions

--- a/api-reference/beta/api/channel-getallretainedmessages.md
+++ b/api-reference/beta/api/channel-getallretainedmessages.md
@@ -24,7 +24,7 @@ To learn more about how to use the Microsoft Teams export APIs to export content
 > This API requires [Teams retention policies](/purview/create-retention-policies?tabs=teams-retention) to be configured. For more information, see [Learn about retention for Microsoft Teams](/purview/retention-policies-teams).
 
 > [!NOTE]
-> This Endpoint Doesn't Support retrieving Retained messages from Teams private channels
+> This endpoint doesn't support retrieving retained messages from Teams private channels.
 
 [!INCLUDE [national-cloud-support](../../includes/all-clouds.md)]
 


### PR DESCRIPTION
As a support engineer from Graph API team, I got confirmation from engineering in ICM 647722926 endpoint not supported with private channels

stating directly in endpoint article help set customers expectations directly

> [!IMPORTANT]
> Required for API changes:
> - Link to API.md file: *ADD LINK HERE*
> - Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl) **VALID PRs DON'T INCLUDE API.MD or permissions JSON FILES**:  *ADD LINK HERE*

---
Add other supporting information, such as a description of the PR changes:

*ADD INFORMATION HERE*

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
