### PR TITLE
updated device threshold

### DIFF
--- a/includes/throttling-device-operation.md
+++ b/includes/throttling-device-operation.md
@@ -7,6 +7,10 @@ ms.topic: include
 ---
 <!-- markdownlint-disable MD041 -->
 
+| Request type |Limit per app per tenant |
+| ------------ |------------------------ |
+| POST, PATCH, DELETE | 3,000 requests per 2 minutes and 30 seconds |
+
 | Request type |Limit per user per tenant |
 | ------------ |------------------------ |
 | POST, PATCH, DELETE | 25 requests per 10 seconds |

--- a/includes/throttling-device-operation.md
+++ b/includes/throttling-device-operation.md
@@ -7,12 +7,8 @@ ms.topic: include
 ---
 <!-- markdownlint-disable MD041 -->
 
-| Request type |Limit per app per tenant |
+| Request type |Limit per app per tenant |Limit per user per tenant |
 | ------------ |------------------------ |
-| POST, PATCH, DELETE | 3,000 requests per 2 minutes and 30 seconds |
-
-| Request type |Limit per user per tenant |
-| ------------ |------------------------ |
-| POST, PATCH, DELETE | 25 requests per 10 seconds |
+| POST, PATCH, DELETE | 3,000 requests per 2 minutes and 30 seconds |25 requests per 10 seconds |
 
 The preceding limits apply to write quota for the [device](/graph/api/resources/device) resource.

--- a/includes/throttling-device-operation.md
+++ b/includes/throttling-device-operation.md
@@ -7,8 +7,8 @@ ms.topic: include
 ---
 <!-- markdownlint-disable MD041 -->
 
-| Request type |Limit per app per tenant |
+| Request type |Limit per user per tenant |
 | ------------ |------------------------ |
-| POST, PATCH, DELETE | 3,000 requests per 2 minutes and 30 seconds |
+| POST, PATCH, DELETE | 25 requests per 10 seconds |
 
-The preceding limits apply to write qouta for the [device](/graph/api/resources/device) resource.
+The preceding limits apply to write quota for the [device](/graph/api/resources/device) resource.

--- a/includes/throttling-device-operation.md
+++ b/includes/throttling-device-operation.md
@@ -8,7 +8,7 @@ ms.topic: include
 <!-- markdownlint-disable MD041 -->
 
 | Request type |Limit per app per tenant |Limit per user per tenant |
-| ------------ |------------------------ |
+| ------------ |------------------------ |------------------------ |
 | POST, PATCH, DELETE | 3,000 requests per 2 minutes and 30 seconds |25 requests per 10 seconds |
 
 The preceding limits apply to write quota for the [device](/graph/api/resources/device) resource.


### PR DESCRIPTION
Per newly implemented thresholds, we update the public documentation to reflect the correct settings
- updated the label of the table to say "Limit per user per tenant" instead of "limint per app per tenant"
- updated the actual limit to "25 requests per 10 seconds"
---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
