### PR TITLE
Add deprecation warning for Document Library tab creation via Graph API

### DIFF
--- a/concepts/teams-configuring-builtin-tabs.md
+++ b/concepts/teams-configuring-builtin-tabs.md
@@ -72,6 +72,9 @@ POST https://graph.microsoft.com/v1.0/teams/{team-id}/channels/{channel-id}/tabs
 
 ## Document library tabs
 
+> [!WARNING]
+> Creating Document Library tabs using the `teamsAppId` `com.microsoft.teamspace.tab.files.sharepoint` is deprecated and no longer supported via Microsoft Graph API.
+
 For document library tabs, the `teamsAppId` is `com.microsoft.teamspace.tab.files.sharepoint`. 
 The following is the configuration.
 


### PR DESCRIPTION
Microsoft support has confirmed that the Document Library tab creation method using app ID `com.microsoft.teamspace.tab.files.sharepoint` is deprecated and no longer supported via Graph API. This commit adds a warning to the documentation to prevent developers from using this outdated method.

> [!IMPORTANT]
> Required for API changes:
> - [] Link to API.md file: *ADD LINK HERE*
> - [] Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl) **PR DOESN'T INCLUDE API.MD or PERMISSIONS CHANGES**:  *ADD LINK HERE*

---
Add other supporting information, such as a description of the PR changes:

This PR adds a `[!WARNING]` callout to the "Document library tabs" section to inform developers that the method for creating document library tabs using the app ID `com.microsoft.teamspace.tab.files.sharepoint` is deprecated and no longer supported via Microsoft Graph API.

The change is based on confirmation from Microsoft support that this method is no longer functional and should not be used. This update helps prevent confusion and errors for developers referencing outdated documentation.

References:
- https://learn.microsoft.com/en-us/answers/questions/2156369/not-able-to-see-document-library-content-inside-ms?comment=answer-1912817&page=1#comment-2088907
- Microsoft External Staff response (via Prasad-MSFT, July 2025)

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
