### PR TITLE
Update plannertask-delta.md

### DIFF
--- a/api-reference/beta/api/plannertask-delta.md
+++ b/api-reference/beta/api/plannertask-delta.md
@@ -33,8 +33,8 @@ Choose the permission or permissions marked as least privileged for this API. Us
 -->
 
 ```http
-GET /planner/tasks/delta
-GET /me/planner/tasks/delta
+GET /planner/plans/{planId}/tasks/delta
+GET /me/planner/plans/{planId}/tasks/delta
 ```
 
 ## Query parameters
@@ -79,7 +79,7 @@ The following example shows a request.
 -->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/planner/tasks/delta
+GET https://graph.microsoft.com/beta/planner/plans/{planId}/tasks/delta
 ```
 
 # [C#](#tab/csharp)
@@ -246,7 +246,7 @@ The following example shows a request.
 -->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/me/planner/tasks/delta
+GET https://graph.microsoft.com/beta/me/planner/plans/{planId}/tasks/delta
 ```
 
 # [C#](#tab/csharp)
@@ -298,7 +298,7 @@ Content-Type: application/json
 
 {
   "@odata.context":"https://graph.microsoft.com/beta/$metadata#plannerTask",
-  "@odata.deltaLink": "https://graph.microsoft.com/beta/me/planner/tasks/delta?%24expand=details&%24deltatoken=0%257eaa6c4c81-656f-40e8-a2c5-60f4116fa9a4",
+  "@odata.deltaLink": "https://graph.microsoft.com/beta/me/planner/plans/{planId}/tasks/delta?%24expand=details&%24deltatoken=0%257eaa6c4c81-656f-40e8-a2c5-60f4116fa9a4",
   "value": [
     {
       "@odata.etag": "W/\"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBASCc=\"",


### PR DESCRIPTION
Changes made to the delta Path as calling /planner/tasks/delta always failed with "When querying this entity set's publication with an app only token, certain fields must be selected to be returned" however it occurs to me i needed to supply a planid in order to be able to query a delta otherwise what am i looking for the delta for

There may be more changes needed for other delta tasks however I'm not using them so not able to test easily

> [!IMPORTANT]
> Required for API changes:
> - [] Link to API.md file: *ADD LINK HERE*
> - [] Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl) **PR DOESN'T INCLUDE API.MD or PERMISSIONS CHANGES**:  *ADD LINK HERE*

---
Add other supporting information, such as a description of the PR changes:

*ADD INFORMATION HERE*

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
