### PR TITLE
Adds info about filterable properties and new example

### DIFF
--- a/api-reference/beta/api/messagetracingroot-list-messagetraces.md
+++ b/api-reference/beta/api/messagetracingroot-list-messagetraces.md
@@ -39,6 +39,22 @@ This method supports the `$filter`, `$top` and `$skipToken` OData query paramete
 
 The default page size for this API is 1000 **exchangeMessageTrace** objects. Use `$top` to customize the page size, within the range of 1 and 5000. To get the next page of message traces, simply apply the entire URL returned in `@odata.nextLink` to the next get-messagetraces request. This URL includes any query parameters you may have specified in the initial request. For more information, see [Paging Microsoft Graph data in your app](/graph/paging).
 
+The following table summarizes support for `$filter` operators by properties of **exchangeMessageTrace** objects.
+
+|Property|Supported operator|
+|:---|:---|
+|id|`eq`|
+|messageId|`eq`|
+|status|`eq`|
+|receivedDateTime| **range must be specified** using the `ge` and `le` operators |
+|recipientAddress|`eq`|
+|senderAddress|`eq`|
+|subject|`contains`, `startsWith`|
+|fromIP|`eq`|
+|toIP|`eq`|
+
+When filtering by the `receivedDateTime` property, the start date cannot be older than 90 days from today.
+
 ## Request headers
 
 |Name|Description|
@@ -55,7 +71,9 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ## Examples
 
-### Request
+### Example 1: Get all message traces
+
+#### Request
 
 The following example shows a request.
 <!-- {
@@ -67,8 +85,7 @@ The following example shows a request.
 GET https://graph.microsoft.com/beta/admin/exchange/tracing/messageTraces
 ```
 
-
-### Response
+#### Response
 
 The following example shows the response.
 >**Note:** The response object shown here might be shortened for readability.
@@ -101,3 +118,51 @@ Content-Type: application/json
 }
 ```
 
+### Example 2: Get message traces by filtering on the receivedDateTime property
+
+This example gets message traces by filtering on their receivedDateTime in specific range. Always specify the start and end date time by using the `ge` and `le` query operators.
+
+#### Request
+
+The following example shows a request.
+<!-- {
+  "blockType": "request",
+  "name": "list_exchangemessagetrace_2"
+}
+-->
+``` http
+GET https://graph.microsoft.com/beta/admin/exchange/tracing/messageTraces?$filter=receivedDateTime ge 2025-06-13T00:00:00.000Z and receivedDateTime le 2025-06-14T00:00:00.000Z
+```
+
+#### Response
+
+The following example shows the response.
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.exchangeMessageTrace"
+}
+-->
+``` http
+HTTP/1.1 200 OK        
+Content-Type: application/json
+
+{
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.exchangeMessageTrace",
+      "id": "4451a062-48cb-e80d-e8c0-196330437ae6",
+      "senderAddress": "sender@contoso.com",
+      "recipientAddress": "recipient@contoso.com",
+      "messageId": "<d9683b4c-127b-413a-ae2e-fa7dfb32c69d@contoso.com>",
+      "receivedDateTime": "2025-06-13T10:30:00Z",
+      "subject": "Quarterly Report",
+      "size": 45678,
+      "fromIP": "192.168.1.100",
+      "toIP": "",
+      "status": "Delivered"
+    }
+  ]
+}
+```


### PR DESCRIPTION
> [!IMPORTANT]
> Required for API changes:
> - [] Link to API.md file: *ADD LINK HERE*
> - [] Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl):  *ADD LINK HERE*

---
Add other supporting information, such as a description of the PR changes:

The PR adds a new example with filtering message trace objects. Added overview which properties support filtering including the supported query operators. 

The API will be used by Exchange admins and not all of them are experienced with OData filtering.

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
