### PR TITLE
Enhance booking appointment update documentation examples

### DIFF
--- a/api-reference/v1.0/api/bookingappointment-update.md
+++ b/api-reference/v1.0/api/bookingappointment-update.md
@@ -83,12 +83,15 @@ If successful, this method returns a `204 No Content` response code. It doesn't 
 
 ## Examples
 
-### Request
+### Example 1: Change the date of service
+
+#### Request
 
 The following example changes the date of service by a day.
 
 <!-- {
   "blockType": "request",
+  "name": "update_bookingappointment_date",
   "sampleKeys": ["AAMkADKnAAA=", "Contosolunchdelivery@contoso.com"]
 }-->
 ```http
@@ -110,7 +113,60 @@ Content-type: application/json
 }
 ```
 
-### Response
+#### Response
+
+The following example shows the response.
+<!-- {
+  "blockType": "response",
+  "truncated": true
+} -->
+```http
+HTTP/1.1 204 No Content
+```
+
+### Example 2: Update the customers for an appointment
+
+The following example updates the customers array for a multi-customer appointment. The **customers** property is a full replacement array — include all customers that should be part of the appointment, not just the new ones.
+
+> [!NOTE]
+> - Each object in the **customers** array must include `@odata.type` set to `#microsoft.graph.bookingCustomerInformation`. Omitting this property causes the request to fail.
+> - Include customer details such as **name**, **emailAddress**, and **phone** for each entry. The API does not automatically populate these fields from the **customerId** — if omitted, they will be blank on the appointment.
+> - The **customerId** must reference a valid [bookingCustomer](../resources/bookingcustomer.md) that exists in the Booking Calendar. If it doesn't exist, create one using the [Create bookingCustomer](bookingbusiness-post-customers.md) operation.
+> - The associated [bookingService](../resources/bookingservice.md) must have **maximumAttendeesCount** greater than 1 to support multiple customers.
+
+#### Request
+
+<!-- {
+  "blockType": "request",
+  "name": "update_bookingappointment_customers",
+  "sampleKeys": ["AAMkADKoAAA=", "Contosolunchdelivery@contoso.com"]
+}-->
+```http
+PATCH https://graph.microsoft.com/v1.0/solutions/bookingBusinesses/Contosolunchdelivery@contoso.com/appointments/AAMkADKoAAA=
+Content-type: application/json
+
+{
+    "@odata.type":"#microsoft.graph.bookingAppointment",
+    "customers": [
+        {
+            "@odata.type": "#microsoft.graph.bookingCustomerInformation",
+            "customerId": "cd56bb19-c348-42c6-af5c-09818c87fb8c",
+            "name": "John Doe",
+            "emailAddress": "john.doe@example.com",
+            "phone": "313-555-5555"
+        },
+        {
+            "@odata.type": "#microsoft.graph.bookingCustomerInformation",
+            "customerId": "72f148fa-9a86-4c59-b277-f5089d9ea0e7",
+            "name": "Jane Smith",
+            "emailAddress": "jane.smith@example.com",
+            "phone": "248-555-5678"
+        }
+    ]
+}
+```
+
+#### Response
 
 The following example shows the response.
 <!-- {

--- a/api-reference/v1.0/api/bookingappointment-update.md
+++ b/api-reference/v1.0/api/bookingappointment-update.md
@@ -117,8 +117,7 @@ Content-type: application/json
 
 The following example shows the response.
 <!-- {
-  "blockType": "response",
-  "truncated": true
+  "blockType": "response"
 } -->
 ```http
 HTTP/1.1 204 No Content


### PR DESCRIPTION
Added examples for updating customers

> [!IMPORTANT]
> Required for API changes:
> - [] Link to API.md file: api-reference/v1.0/api/bookingappointment-update.md
> - [] Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl):  N/A — no schema changes; documentation-only update adding a new example.
> - [] Attach the documentation plan generated for AI-assisted docs authoring and validation to help speed up content review.

---
Add other supporting information, such as a description of the PR changes:

Summary: Adds a second example to the Update bookingAppointment documentation showing how to update the customers array on a multi-customer appointment via PATCH.

What changed:

- Renamed the existing example to Example 1: Change the date of service
- Added Example 2: Update the customers for an appointment with a validated PATCH payload that updates the customers array with two bookingCustomerInformation entries
- Added notes clarifying requirements that are not currently documented:

1. @odata.type set to #microsoft.graph.bookingCustomerInformation is required on each customer object in the array — omitting it causes the request to fail
2. Customer details (name, emailAddress, phone) should be included alongside customerId — the API does not auto-populate these fields from the customer record
3. The customers array is a full replacement — all customers must be included, not just new additions
4. The associated bookingService must have maximumAttendeesCount > 1

Why: A customer filed a support case reporting they could not add a second customer to a Bookings appointment via PATCH. The existing documentation only contains a date-change example and does not show a customers array update. The payload requirements (especially the mandatory @odata.type on each entry) are not documented, and AI assistants (including Copilot) were giving incorrect guidance (e.g., suggesting filledAttendeesCount must be manually updated, or that only customerId should be sent). The new example and notes were validated against the live API.

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
