### PR TITLE
Add allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled to onPremisesDirectorySynchronizationFeature

### DIFF
--- a/api-reference/beta/resources/onpremisesdirectorysynchronizationfeature.md
+++ b/api-reference/beta/resources/onpremisesdirectorysynchronizationfeature.md
@@ -6,7 +6,7 @@ ms.reviewer: damaiya,vifernan,awsdev
 ms.localizationpriority: medium
 ms.subservice: "entra-directory-management"
 doc_type: resourcePageType
-ms.date: 10/03/2024
+ms.date: 04/23/2026
 ---
 
 # onPremisesDirectorySynchronizationFeature resource type
@@ -21,6 +21,7 @@ Consists of [directory synchronization](../resources/onpremisesdirectorysynchron
 
 | Property                                         | Type    | Description                                                                                                                                                  |
 | :----------------------------------------------- | :------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled | Boolean | When `true`, allows on-premises directory sync clients to update the `onPremisesObjectIdentifier` property.                                                |
 | blockCloudObjectTakeoverThroughHardMatchEnabled  | Boolean | Used to block cloud object takeover via source anchor hard match if enabled.                                                                                 |
 | blockSoftMatchEnabled                            | Boolean | Use to block soft match for all objects if enabled for the  tenant. Customers are encouraged to enable this feature and keep it enabled until soft matching is required again for their tenancy. This flag should be enabled again after any soft matching has been completed and is no longer needed.                                                                                                  |
 | bypassDirSyncOverridesEnabled                    | Boolean | When `true`, persists the values of _Mobile_ and _OtherMobile_ in on-premises AD during sync cycles instead of values of _MobilePhone_ or _AlternateMobilePhones_ in Microsoft Entra ID.                                    |
@@ -74,6 +75,7 @@ The following JSON representation shows the resource type.
   "groupWriteBackEnabled": "Boolean",
   "blockSoftMatchEnabled": "Boolean",
   "blockCloudObjectTakeoverThroughHardMatchEnabled": "Boolean",
-  "bypassDirSyncOverridesEnabled": "Boolean"
+  "bypassDirSyncOverridesEnabled": "Boolean",
+  "allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled": "Boolean"
 }
 ```

--- a/api-reference/v1.0/resources/onpremisesdirectorysynchronizationfeature.md
+++ b/api-reference/v1.0/resources/onpremisesdirectorysynchronizationfeature.md
@@ -6,7 +6,7 @@ ms.reviewer: damaiya,vifernan,awsdev
 ms.localizationpriority: medium
 ms.subservice: "entra-directory-management"
 doc_type: resourcePageType
-ms.date: 10/03/2024
+ms.date: 04/23/2026
 ---
 
 # onPremisesDirectorySynchronizationFeature resource type
@@ -19,6 +19,7 @@ Consists of directory synchronization features that can be enabled or disabled. 
 
 | Property                                         | Type    | Description                                                                                                                                                                                                                                                                                            |
 | :----------------------------------------------- | :------ | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled | Boolean | When `true`, allows on-premises directory sync clients to update the `onPremisesObjectIdentifier` property.                                                                                                                                                                                          |
 | blockCloudObjectTakeoverThroughHardMatchEnabled  | Boolean | Used to block cloud object takeover via source anchor hard match if enabled.                                                                                                                                                                                                                           |
 | blockSoftMatchEnabled                            | Boolean | Use to block soft match for all objects if enabled for the  tenant. Customers are encouraged to enable this feature and keep it enabled until soft matching is required again for their tenancy. This flag should be enabled again after any soft matching has been completed and is no longer needed. |
 | bypassDirSyncOverridesEnabled                    | Boolean | When `true`, persists the values of _Mobile_ and _OtherMobile_ in on-premises AD during sync cycles instead of values of _MobilePhone_ or _AlternateMobilePhones_ in Microsoft Entra ID.                                                                                                                         |
@@ -72,6 +73,7 @@ The following JSON representation shows the resource type.
   "groupWriteBackEnabled": "Boolean",
   "blockSoftMatchEnabled": "Boolean",
   "blockCloudObjectTakeoverThroughHardMatchEnabled": "Boolean",
-  "bypassDirSyncOverridesEnabled": "Boolean"
+  "bypassDirSyncOverridesEnabled": "Boolean",
+  "allowOnPremUpdateOfOnPremisesObjectIdentifierEnabled": "Boolean"
 }
 ```


### PR DESCRIPTION
## Summary

Adds the \llowOnPremUpdateOfOnPremisesObjectIdentifierEnabled\ boolean property to the \onPremisesDirectorySynchronizationFeature\ resource type documentation for both **beta** and **v1.0** API references.

This is a new DirSync feature flag that allows on-premises directory sync clients to update the \onPremisesObjectIdentifier\ property.

## Changes

- **beta/resources/onpremisesdirectorysynchronizationfeature.md**: Added property to properties table and JSON representation
- **v1.0/resources/onpremisesdirectorysynchronizationfeature.md**: Added property to properties table and JSON representation

## Related

- Schema promotion PR: https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/15477641
- API review PR: https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/15261649
