### PR TITLE
Add 23 scheduleEntityTheme color members (v1.0 + beta)

### DIFF
--- a/api-reference/beta/resources/enums.md
+++ b/api-reference/beta/resources/enums.md
@@ -2277,6 +2277,29 @@ Namespace: microsoft.graph
 | darkPink |
 | darkYellow |
 | unknownFutureValue |
+| darkRed |
+| cranberry |
+| darkOrange |
+| bronze |
+| peach |
+| gold |
+| lime |
+| forest |
+| lightGreen |
+| jade |
+| lightTeal |
+| darkTeal |
+| steel |
+| skyBlue |
+| blueGray |
+| lavender |
+| lilac |
+| plum |
+| magenta |
+| darkBrown |
+| beige |
+| charcoal |
+| silver |
 
 ### timeOffReasonIconType values
 

--- a/api-reference/v1.0/resources/enums.md
+++ b/api-reference/v1.0/resources/enums.md
@@ -1287,6 +1287,29 @@ Namespace: microsoft.graph
 | darkPink |
 | darkYellow |
 | unknownFutureValue |
+| darkRed |
+| cranberry |
+| darkOrange |
+| bronze |
+| peach |
+| gold |
+| lime |
+| forest |
+| lightGreen |
+| jade |
+| lightTeal |
+| darkTeal |
+| steel |
+| skyBlue |
+| blueGray |
+| lavender |
+| lilac |
+| plum |
+| magenta |
+| darkBrown |
+| beige |
+| charcoal |
+| silver |
 
 ### timeOffReasonIconType values
 


### PR DESCRIPTION
## Summary
- Extends the `scheduleEntityTheme` enum in `api-reference/v1.0/resources/enums.md` and `api-reference/beta/resources/enums.md` with 23 new color themes, added after `unknownFutureValue` per evolvable-enum convention.
- New members (values 13–35 in CSDL): `darkRed`, `cranberry`, `darkOrange`, `bronze`, `peach`, `gold`, `lime`, `forest`, `lightGreen`, `jade`, `lightTeal`, `darkTeal`, `steel`, `skyBlue`, `blueGray`, `lavender`, `lilac`, `plum`, `magenta`, `darkBrown`, `beige`, `charcoal`, `silver`.
- Sourced from the Shifts schema PR: https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/15488646

## Test plan
- [ ] Doc build / link-check passes in CI
- [ ] Spot-check rendered enum table on `resources/enums.md` (v1.0 and beta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)