### PR TITLE
docs: add note about read-only group calendar container properties

### DIFF
--- a/api-reference/beta/api/calendar-update.md
+++ b/api-reference/beta/api/calendar-update.md
@@ -61,6 +61,9 @@ In the request body, supply the values for relevant fields that should be update
 |isDefaultCalendar|Boolean|True if this calendar is the user's default calendar, false otherwise.|
 |name|String|The calendar name.|
 
+> [!IMPORTANT]
+> Calendar container properties in group calendars are read-only and can't be modified. `PATCH` requests that target these properties fail with a `405 Method Not Allowed` response.
+
 ## Response
 
 If successful, this method returns a `200 OK` response code and updated [calendar](../resources/calendar.md) object in the response body.

--- a/api-reference/v1.0/api/calendar-update.md
+++ b/api-reference/v1.0/api/calendar-update.md
@@ -60,7 +60,7 @@ In the request body, supply the values for relevant fields that should be update
 |name|String|The calendar name.|
 
 > [!IMPORTANT]
-> Calendar container properties in group calendars are read-only and cannot be modified. PATCH requests targeting these properties will fail with a 405 Method Not Allowed response.
+> Calendar container properties in group calendars are read-only and can't be modified. `PATCH` requests that target these properties fail with a `405 Method Not Allowed` response.
 
 ## Response
 

--- a/api-reference/v1.0/api/calendar-update.md
+++ b/api-reference/v1.0/api/calendar-update.md
@@ -59,6 +59,9 @@ In the request body, supply the values for relevant fields that should be update
 |isDefaultCalendar|Boolean|True if this calendar is the user's default calendar, false otherwise.|
 |name|String|The calendar name.|
 
+> [!IMPORTANT]
+> Calendar container properties in group calendars are read-only and cannot be modified. PATCH requests targeting these properties will fail with a 405 Method Not Allowed response.
+
 ## Response
 
 If successful, this method returns a `200 OK` response code and updated [calendar](../resources/calendar.md) object in the response body.


### PR DESCRIPTION
## Summary

- Added an `[!IMPORTANT]` callout in the **Request body** section of `calendar-update.md` to clarify that calendar container properties in group calendars are read-only.
- PATCH requests targeting these properties return `405 Method Not Allowed`.

## Test plan

- [x] Verify the callout renders correctly in the docs preview.
- [x] Confirm placement is after the request body property table and before the Response section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)