### PR TITLE
Fix endpoint path for calendar permanent delete

### DIFF
--- a/api-reference/beta/api/calendar-permanentdelete.md
+++ b/api-reference/beta/api/calendar-permanentdelete.md
@@ -34,7 +34,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 }
 -->
 ``` http
-POST /users/{usersId}/calendar/permanentDelete
+POST /users/{usersId}/calendars/permanentDelete
 POST /groups/{groupsId}/calendar/permanentDelete
 ```
 
@@ -64,7 +64,7 @@ The following example shows a request.
 }
 -->
 ``` http
-POST https://graph.microsoft.com/beta/users/{usersId}/calendar/permanentDelete
+POST https://graph.microsoft.com/beta/users/{usersId}/calendars/permanentDelete
 ```
 
 # [C#](#tab/csharp)

--- a/api-reference/v1.0/api/calendar-permanentdelete.md
+++ b/api-reference/v1.0/api/calendar-permanentdelete.md
@@ -64,7 +64,7 @@ The following example shows a request.
 }
 -->
 ``` http
-POST https://graph.microsoft.com/v1.0/users/b4c80c57-5c59-4a3d-912a-a83985988b82/calendar/permanentDelete
+POST https://graph.microsoft.com/v1.0/users/b4c80c57-5c59-4a3d-912a-a83985988b82/calendars/permanentDelete
 ```
 
 # [C#](#tab/csharp)

--- a/api-reference/v1.0/api/calendar-permanentdelete.md
+++ b/api-reference/v1.0/api/calendar-permanentdelete.md
@@ -34,7 +34,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 }
 -->
 ``` http
-POST /users/{id | userPrincipalName}/calendar/{calendarId}/permanentDelete
+POST /users/{id | userPrincipalName}/calendars/{calendarId}/permanentDelete
 ```
 
 ## Request headers


### PR DESCRIPTION
Fixing the issue in documentation. Issue raised by Loc Le, Tarun Chopra, Sudhamsu Mylavarapu. calendar-permanentDelete endpoint path (missing 's' in calendars)

> [!IMPORTANT]
> Required for API changes:
> - [] Link to API.md file: *ADD LINK HERE*
> - [] Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl):  *ADD LINK HERE*
> - [] Attach the documentation plan generated for AI-assisted docs authoring and validation to help speed up content review.

---
Add other supporting information, such as a description of the PR changes:

*ADD INFORMATION HERE*

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
