### PR TITLE
Switch from camelCase to PascalCase for `activity` and `availability` in Presence

### DIFF
--- a/api-reference/beta/resources/presence.md
+++ b/api-reference/beta/resources/presence.md
@@ -38,8 +38,8 @@ This resource supports subscribing to [change notifications](/graph/changenotifi
 
 | Property            | Type               | Description                                     |
 | :------------------ | :------------------| :---------------------------------------        |
-| activity            | String             | The supplemental information to a user's availability. Possible values are `available`, `away`, `beRightBack`, `busy`, `doNotDisturb`, `offline`, `outOfOffice`, `presenceUnknown`. |
-| availability        | String             | The base presence information for a user. Possible values are `available`, `away`, `beRightBack`, `busy`, `doNotDisturb`, `focusing`, `inACall`, `inAMeeting`, `offline`, `presenting`, `presenceUnknown`.    |
+| activity            | String             | The supplemental information to a user's availability. Possible values are `Available`, `Away`, `BeRightBack`, `Busy`, `DoNotDisturb`, `Offline`, `OutOfOffice`, `PresenceUnknown`. |
+| availability        | String             | The base presence information for a user. Possible values are `Available`, `Away`, `BeRightBack`, `Busy`, `DoNotDisturb`, `Focusing`, `InACall`, `InAMeeting`, `Offline`, `Presenting`, `PresenceUnknown`.    |
 | id                  | String             | The unique identifier for the user. |
 | outOfOfficeSettings | [outOfOfficeSettings](outofofficesettings.md) | The out of office settings for a user.  |
 | sequenceNumber      | String             | The lexicographically sortable String stamp that represents the version of a **presence** object. |

--- a/api-reference/v1.0/resources/presence.md
+++ b/api-reference/v1.0/resources/presence.md
@@ -36,8 +36,8 @@ This resource supports subscribing to [change notifications](/graph/changenotifi
 
 | Property            | Type               | Description                                     |
 | :------------------ | :------------------| :---------------------------------------        |
-| activity            | String             | The supplemental information to a user's availability. Possible values are `available`, `away`, `beRightBack`, `busy`, `doNotDisturb`, `offline`, `outOfOffice`, `presenceUnknown`. |
-| availability        | String             | The base presence information for a user. Possible values are `available`, `away`, `beRightBack`, `busy`, `doNotDisturb`, `focusing`, `inACall`, `inAMeeting`, `offline`, `presenting`, `presenceUnknown`.    |
+| activity            | String             | The supplemental information to a user's availability. Possible values are `Available`, `Away`, `BeRightBack`, `Busy`, `DoNotDisturb`, `Offline`, `OutOfOffice`, `PresenceUnknown`. |
+| availability        | String             | The base presence information for a user. Possible values are `Available`, `Away`, `BeRightBack`, `Busy`, `DoNotDisturb`, `Focusing`, `InACall`, `InAMeeting`, `Offline`, `Presenting`, `PresenceUnknown`.    |
 | id                  | String             | The unique identifier for the user. |
 | outOfOfficeSettings | [outOfOfficeSettings](outofofficesettings.md) | The out of office settings for a user.  |
 | sequenceNumber      | String             | The lexicographically sortable String stamp that represents the version of a **presence** object. |


### PR DESCRIPTION
It seems that this commit: ca252117e8e9d4ee9dbf62f38dd19615a6dcdbed switched from PascalCase to camelCase for user [Presence](https://learn.microsoft.com/en-us/graph/api/resources/presence?view=graph-rest-1.0). But the API is still returning values in PascalCase.

<img width="1844" height="1275" alt="Screenshot 2026-05-07 at 10 03 12" src="https://github.com/user-attachments/assets/1d62312c-7f97-44ac-82b4-53c047b0b1fd" />

All other API documentation also uses PascalCase: 
- https://learn.microsoft.com/en-us/graph/api/presence-setuserpreferredpresence?view=graph-rest-1.0&tabs=http
- https://learn.microsoft.com/en-us/graph/api/presence-setpresence?view=graph-rest-1.0&tabs=http