### PR TITLE
Fixed boilerplate sentence for response examples

### DIFF
--- a/api-reference/beta/api/m365appsinstallationoptions-get.md
+++ b/api-reference/beta/api/m365appsinstallationoptions-get.md
@@ -55,7 +55,7 @@ If successful, this method returns a `200 OK` response code and a [m365AppsInsta
 ## Examples
 
 ### Request
-The following example shows a request.
+The following example shows the request.
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",

--- a/api-reference/beta/api/m365appsinstallationoptions-get.md
+++ b/api-reference/beta/api/m365appsinstallationoptions-get.md
@@ -55,7 +55,7 @@ If successful, this method returns a `200 OK` response code and a [m365AppsInsta
 ## Examples
 
 ### Request
-The following example shows the request.
+The following example shows a request.
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -93,7 +93,7 @@ GET https://graph.microsoft.com/beta/admin/microsoft365Apps/installationOptions
 ---
 
 ### Response
-The following example shows a response.
+The following example shows the response.
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/networkaccess-forwardingpolicy-updatepolicyrules.md
+++ b/api-reference/beta/api/networkaccess-forwardingpolicy-updatepolicyrules.md
@@ -87,7 +87,7 @@ Content-Type: application/json
 ---
 
 ### Response
-The following example shows a response.
+The following example shows the response.
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/beta/api/security-ediscoveryreviewset-export.md
+++ b/api-reference/beta/api/security-ediscoveryreviewset-export.md
@@ -113,7 +113,7 @@ Content-Type: application/json
 ---
 
 ### Response
-The following example shows a response.
+The following example shows the response.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/educationclass-delete-teachers.md
+++ b/api-reference/v1.0/api/educationclass-delete-teachers.md
@@ -59,7 +59,7 @@ DELETE https://graph.microsoft.com/v1.0/education/classes/{class-id}/teachers/{t
 ---
 
 ### Response
-The following example shows a response. 
+The following example shows the response. 
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/v1.0/api/m365appsinstallationoptions-get.md
+++ b/api-reference/v1.0/api/m365appsinstallationoptions-get.md
@@ -91,7 +91,7 @@ GET https://graph.microsoft.com/v1.0/admin/microsoft365Apps/installationOptions
 ---
 
 ### Response
-The following example shows a response.
+The following example shows the response.
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",


### PR DESCRIPTION
Replaced "The following example shows a response." with "The following example shows the response."