### PR TITLE
docs: Clarify MTO tenant API permission-to-property mapping and role access

### DIFF
--- a/api-reference/beta/api/multitenantorganization-list-tenants.md
+++ b/api-reference/beta/api/multitenantorganization-list-tenants.md
@@ -5,7 +5,7 @@ author: "rolyon"
 ms.localizationpriority: medium
 ms.subservice: "entra-sign-in"
 doc_type: apiPageType
-ms.date: 04/05/2024
+ms.date: 05/14/2026
 ---
 
 # List multiTenantOrganizationMembers
@@ -23,7 +23,11 @@ Choose the permission or permissions marked as least privileged for this API. Us
 <!-- { "blockType": "permissions", "name": "multitenantorganization_list_tenants" } -->
 [!INCLUDE [permissions-table](../includes/permissions/multitenantorganization-list-tenants-permissions.md)]
 
-If called with MultiTenantOrganization.Read.All or MultiTenantOrganization.ReadWrite.All permissions, this API returns both active and pending tenants. If called with MultiTenantOrganization.ReadBasic.All permission, the caller can only read the **displayName** and **tenantId** properties.
+The properties returned depend on the permission granted:
+
+- **MultiTenantOrganization.ReadBasic.All** (delegated): Returns only the **displayName** and **tenantId** properties. Only active tenants are returned.
+- **MultiTenantOrganization.Read.All** or **Directory.Read.All** (delegated or application): Returns all properties, including **addedDateTime**, **joinedDateTime**, **addedByTenantId**, **role**, **state**, and **transitionDetails**. Both active and pending tenants are returned.
+- **MultiTenantOrganization.ReadWrite.All** (delegated or application): Same access as MultiTenantOrganization.Read.All.
 
 [!INCLUDE [rbac-multitenantorganization-apis-read](../includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md)]
 

--- a/api-reference/beta/api/multitenantorganizationmember-get.md
+++ b/api-reference/beta/api/multitenantorganizationmember-get.md
@@ -5,7 +5,7 @@ author: "rolyon"
 ms.localizationpriority: medium
 ms.subservice: "entra-sign-in"
 doc_type: apiPageType
-ms.date: 04/05/2024
+ms.date: 05/14/2026
 ---
 
 # Get multiTenantOrganizationMember
@@ -23,7 +23,10 @@ Choose the permission or permissions marked as least privileged for this API. Us
 <!-- { "blockType": "permissions", "name": "multitenantorganizationmember_get" } -->
 [!INCLUDE [permissions-table](../includes/permissions/multitenantorganizationmember-get-permissions.md)]
 
-If called with MultiTenantOrganization.ReadBasic.All permission, the caller can only read the **displayName** and **tenantId** properties.
+The properties returned depend on the permission granted:
+
+- **MultiTenantOrganization.ReadBasic.All** (delegated): Returns only the **displayName** and **tenantId** properties.
+- **MultiTenantOrganization.ReadWrite.All** or **Directory.Read.All** (delegated or application): Returns all properties, including **addedDateTime**, **joinedDateTime**, **addedByTenantId**, **role**, **state**, and **transitionDetails**.
 
 [!INCLUDE [rbac-multitenantorganization-apis-read](../includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md)]
 

--- a/api-reference/beta/includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md
+++ b/api-reference/beta/includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md
@@ -5,7 +5,7 @@ ms.topic: include
 
 > [!IMPORTANT]
 > For delegated access using work or school accounts, the signed-in user must be assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. This operation supports the following built-in roles, which provide only the least privilege necessary:
-> - **Security Reader** — Can read basic tenant information (**displayName** and **tenantId** only).
-> - **Global Reader** — Can read basic tenant information (**displayName** and **tenantId** only).
+> - Security Reader
+> - Global Reader
 >
-> To read all properties (including **role**, **state**, **addedByTenantId**, **addedDateTime**, **joinedDateTime**, and **transitionDetails**), the signed-in user must be assigned a role that grants the `MultiTenantOrganization.Read.All` or `MultiTenantOrganization.ReadWrite.All` permission, such as the **Global Administrator** role.
+> These roles grant limited read access. To read all properties, the signed-in user must be assigned a role with the `MultiTenantOrganization.Read.All` or `MultiTenantOrganization.ReadWrite.All` permission.

--- a/api-reference/beta/includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md
+++ b/api-reference/beta/includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md
@@ -5,5 +5,7 @@ ms.topic: include
 
 > [!IMPORTANT]
 > For delegated access using work or school accounts, the signed-in user must be assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. This operation supports the following built-in roles, which provide only the least privilege necessary:
-> - Security Reader
-> - Global Reader
+> - **Security Reader** — Can read basic tenant information (**displayName** and **tenantId** only).
+> - **Global Reader** — Can read basic tenant information (**displayName** and **tenantId** only).
+>
+> To read all properties (including **role**, **state**, **addedByTenantId**, **addedDateTime**, **joinedDateTime**, and **transitionDetails**), the signed-in user must be assigned a role that grants the `MultiTenantOrganization.Read.All` or `MultiTenantOrganization.ReadWrite.All` permission, such as the **Global Administrator** role.

--- a/api-reference/v1.0/api/multitenantorganization-list-tenants.md
+++ b/api-reference/v1.0/api/multitenantorganization-list-tenants.md
@@ -5,7 +5,7 @@ author: "rolyon"
 ms.localizationpriority: medium
 ms.subservice: "entra-sign-in"
 doc_type: apiPageType
-ms.date: 06/21/2024
+ms.date: 05/14/2026
 ---
 
 # List multiTenantOrganizationMembers
@@ -21,7 +21,11 @@ Choose the permission or permissions marked as least privileged for this API. Us
 <!-- { "blockType": "permissions", "name": "multitenantorganization_list_tenants" } -->
 [!INCLUDE [permissions-table](../includes/permissions/multitenantorganization-list-tenants-permissions.md)]
 
-If called with MultiTenantOrganization.Read.All or MultiTenantOrganization.ReadWrite.All permissions, this API returns both active and pending tenants. If called with MultiTenantOrganization.ReadBasic.All permission, the caller can only read the **displayName** and **tenantId** properties.
+The properties returned depend on the permission granted:
+
+- **MultiTenantOrganization.ReadBasic.All** (delegated): Returns only the **displayName** and **tenantId** properties. Only active tenants are returned.
+- **MultiTenantOrganization.Read.All** or **Directory.Read.All** (delegated or application): Returns all properties, including **addedDateTime**, **joinedDateTime**, **addedByTenantId**, **role**, **state**, and **transitionDetails**. Both active and pending tenants are returned.
+- **MultiTenantOrganization.ReadWrite.All** (delegated or application): Same access as MultiTenantOrganization.Read.All.
 
 [!INCLUDE [rbac-multitenantorganization-apis-read](../includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md)]
 

--- a/api-reference/v1.0/api/multitenantorganizationmember-get.md
+++ b/api-reference/v1.0/api/multitenantorganizationmember-get.md
@@ -5,7 +5,7 @@ author: "rolyon"
 ms.localizationpriority: medium
 ms.subservice: "entra-sign-in"
 doc_type: apiPageType
-ms.date: 06/21/2024
+ms.date: 05/14/2026
 ---
 
 # Get multiTenantOrganizationMember
@@ -21,7 +21,10 @@ Choose the permission or permissions marked as least privileged for this API. Us
 <!-- { "blockType": "permissions", "name": "multitenantorganizationmember_get" } -->
 [!INCLUDE [permissions-table](../includes/permissions/multitenantorganizationmember-get-permissions.md)]
 
-If called with MultiTenantOrganization.ReadBasic.All permission, the caller can only read the **displayName** and **tenantId** properties.
+The properties returned depend on the permission granted:
+
+- **MultiTenantOrganization.ReadBasic.All** (delegated): Returns only the **displayName** and **tenantId** properties.
+- **MultiTenantOrganization.ReadWrite.All** or **Directory.Read.All** (delegated or application): Returns all properties, including **addedDateTime**, **joinedDateTime**, **addedByTenantId**, **role**, **state**, and **transitionDetails**.
 
 [!INCLUDE [rbac-multitenantorganization-apis-read](../includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md)]
 

--- a/api-reference/v1.0/includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md
+++ b/api-reference/v1.0/includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md
@@ -5,7 +5,7 @@ ms.topic: include
 
 > [!IMPORTANT]
 > For delegated access using work or school accounts, the signed-in user must be assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. This operation supports the following built-in roles, which provide only the least privilege necessary:
-> - **Security Reader** — Can read basic tenant information (**displayName** and **tenantId** only).
-> - **Global Reader** — Can read basic tenant information (**displayName** and **tenantId** only).
+> - Security Reader
+> - Global Reader
 >
-> To read all properties (including **role**, **state**, **addedByTenantId**, **addedDateTime**, **joinedDateTime**, and **transitionDetails**), the signed-in user must be assigned a role that grants the `MultiTenantOrganization.Read.All` or `MultiTenantOrganization.ReadWrite.All` permission, such as the **Global Administrator** role.
+> These roles grant limited read access. To read all properties, the signed-in user must be assigned a role with the `MultiTenantOrganization.Read.All` or `MultiTenantOrganization.ReadWrite.All` permission.

--- a/api-reference/v1.0/includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md
+++ b/api-reference/v1.0/includes/rbac-for-apis/rbac-multitenantorganization-apis-read.md
@@ -5,5 +5,7 @@ ms.topic: include
 
 > [!IMPORTANT]
 > For delegated access using work or school accounts, the signed-in user must be assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. This operation supports the following built-in roles, which provide only the least privilege necessary:
-> - Security Reader
-> - Global Reader
+> - **Security Reader** — Can read basic tenant information (**displayName** and **tenantId** only).
+> - **Global Reader** — Can read basic tenant information (**displayName** and **tenantId** only).
+>
+> To read all properties (including **role**, **state**, **addedByTenantId**, **addedDateTime**, **joinedDateTime**, and **transitionDetails**), the signed-in user must be assigned a role that grants the `MultiTenantOrganization.Read.All` or `MultiTenantOrganization.ReadWrite.All` permission, such as the **Global Administrator** role.


### PR DESCRIPTION
> [!IMPORTANT]
> Required for API changes:
> - [x] Link to API.md file: [multitenantorganization-list-tenants (v1.0)](https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/v1.0/api/multitenantorganization-list-tenants.md), [multitenantorganization-list-tenants (beta)](https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/beta/api/multitenantorganization-list-tenants.md), [multitenantorganizationmember-get (v1.0)](https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/v1.0/api/multitenantorganizationmember-get.md), [multitenantorganizationmember-get (beta)](https://github.com/microsoftgraph/microsoft-graph-docs-contrib/blob/main/api-reference/beta/api/multitenantorganizationmember-get.md)
> - [x] Link to PR for public-facing schema changes: N/A (documentation-only, no schema changes)
> - [x] Attach documentation plan: N/A (prose clarification only)

---

## Summary

Clarifies which permissions and Entra roles grant access to multitenant organization tenant data, and documents the properties returned at each permission level.

**Addresses IcM 31000000597799**  MSRC reported `Directory.Read.All` granting access to `/tenantRelationships/multiTenantOrganization/tenants` as an authorization bypass. Investigation confirmed this is **by design**; the documentation simply failed to list `Directory.Read.All` as a valid permission.

### Changes

**List tenants API** (`multitenantorganization-list-tenants.md`, v1.0 + beta):
- Added permission-to-property mapping showing which properties are returned for `ReadBasic.All`, `Read.All`, `Directory.Read.All`, and `ReadWrite.All`

**Get tenant API** (`multitenantorganizationmember-get.md`, v1.0 + beta):
- Same permission-to-property mapping applied for consistency

**RBAC include** (`rbac-multitenantorganization-apis-read.md`, v1.0 + beta):
- Clarified Security Reader / Global Reader only return `displayName` and `tenantId`
- Added guidance on roles needed for full property access

### Notes
- Auto-generated permissions tables (`DO NOT MODIFY`) were **not** modified
- All changes are to explanatory prose and RBAC role documentation only

---