### PR TITLE
Fixed Note blockquote formatting in response examples in v1.0 topics

### DIFF
--- a/api-reference/v1.0/api/administrativeunit-delete-scopedrolemembers.md
+++ b/api-reference/v1.0/api/administrativeunit-delete-scopedrolemembers.md
@@ -88,7 +88,9 @@ DELETE https://graph.microsoft.com/v1.0/directory/administrativeUnits/{id}/scope
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/administrativeunit-delete.md
+++ b/api-reference/v1.0/api/administrativeunit-delete.md
@@ -88,7 +88,9 @@ DELETE https://graph.microsoft.com/v1.0/directory/administrativeUnits/{id}
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/administrativeunit-get-scopedrolemembers.md
+++ b/api-reference/v1.0/api/administrativeunit-get-scopedrolemembers.md
@@ -89,7 +89,9 @@ GET https://graph.microsoft.com/v1.0/directory/administrativeUnits/{id}/scopedRo
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/administrativeunit-list-scopedrolemembers.md
+++ b/api-reference/v1.0/api/administrativeunit-list-scopedrolemembers.md
@@ -89,7 +89,9 @@ GET https://graph.microsoft.com/v1.0/directory/administrativeUnits/8a07f5a8-edc9
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/administrativeunit-post-scopedrolemembers.md
+++ b/api-reference/v1.0/api/administrativeunit-post-scopedrolemembers.md
@@ -97,7 +97,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [scopedRoleMembership](../resources/scopedrolemembership.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/attachment-get.md
+++ b/api-reference/v1.0/api/attachment-get.md
@@ -209,7 +209,9 @@ GET https://graph.microsoft.com/v1.0/me/messages/AAMkAGUzY5QKjAAA=/attachments/A
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "get_file_attachment_v1",
@@ -605,7 +607,9 @@ GET https://graph.microsoft.com/v1.0/me/messages/AAMkAGUzY5QKgAAA=/attachments/A
 ---
 
 #### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "get_reference_attachment",

--- a/api-reference/v1.0/api/bookingbusiness-post-bookingbusinesses.md
+++ b/api-reference/v1.0/api/bookingbusiness-post-bookingbusinesses.md
@@ -103,7 +103,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/bookingbusiness-update.md
+++ b/api-reference/v1.0/api/bookingbusiness-update.md
@@ -107,7 +107,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/bookingcurrency-get.md
+++ b/api-reference/v1.0/api/bookingcurrency-get.md
@@ -84,7 +84,9 @@ GET https://graph.microsoft.com/v1.0/solutions/bookingCurrencies/USD
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/bookingcustomer-update.md
+++ b/api-reference/v1.0/api/bookingcustomer-update.md
@@ -105,7 +105,9 @@ Content-type: application/json
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/calendar-get.md
+++ b/api-reference/v1.0/api/calendar-get.md
@@ -106,7 +106,9 @@ GET https://graph.microsoft.com/v1.0/me/calendar
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/calendar-getschedule.md
+++ b/api-reference/v1.0/api/calendar-getschedule.md
@@ -107,7 +107,9 @@ Content-Type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/calendar-list-events.md
+++ b/api-reference/v1.0/api/calendar-list-events.md
@@ -117,7 +117,9 @@ GET https://graph.microsoft.com/v1.0/me/calendar/events
 
 ##### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",
@@ -196,7 +198,9 @@ GET https://graph.microsoft.com/v1.0/me/calendar/events?$filter=startsWith(subje
 
 #### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/calendar-update.md
+++ b/api-reference/v1.0/api/calendar-update.md
@@ -110,7 +110,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/calendargroup-delete.md
+++ b/api-reference/v1.0/api/calendargroup-delete.md
@@ -95,7 +95,9 @@ DELETE https://graph.microsoft.com/v1.0/me/calendarGroups/{id}
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/calendargroup-list-calendars.md
+++ b/api-reference/v1.0/api/calendargroup-list-calendars.md
@@ -109,7 +109,9 @@ GET https://graph.microsoft.com/v1.0/me/calendarGroups/AAMkAGVmMDEzMTM4LTZmYWUtN
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/calendargroup-post-calendars.md
+++ b/api-reference/v1.0/api/calendargroup-post-calendars.md
@@ -116,7 +116,9 @@ In the request body, supply a JSON representation of [calendar](../resources/cal
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/calendargroup-update.md
+++ b/api-reference/v1.0/api/calendargroup-update.md
@@ -107,7 +107,9 @@ Content-type: application/json
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/chart-get.md
+++ b/api-reference/v1.0/api/chart-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chart-image.md
+++ b/api-reference/v1.0/api/chart-image.md
@@ -97,7 +97,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- { "blockType": "response", "@odata.type": "Edm.String" } -->
 

--- a/api-reference/v1.0/api/chart-list-series.md
+++ b/api-reference/v1.0/api/chart-list-series.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chart-list.md
+++ b/api-reference/v1.0/api/chart-list.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chart-post-series.md
+++ b/api-reference/v1.0/api/chart-post-series.md
@@ -88,7 +88,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [workbookChartSeries](../resources/workbookchartseries.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartaxis-get.md
+++ b/api-reference/v1.0/api/chartaxis-get.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartaxis-update.md
+++ b/api-reference/v1.0/api/chartaxis-update.md
@@ -104,7 +104,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartaxistitle-get.md
+++ b/api-reference/v1.0/api/chartaxistitle-get.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartaxistitle-update.md
+++ b/api-reference/v1.0/api/chartaxistitle-update.md
@@ -98,7 +98,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartcollection-add.md
+++ b/api-reference/v1.0/api/chartcollection-add.md
@@ -96,7 +96,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartcollection-itemat.md
+++ b/api-reference/v1.0/api/chartcollection-itemat.md
@@ -97,7 +97,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartdatalabels-get.md
+++ b/api-reference/v1.0/api/chartdatalabels-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartdatalabels-update.md
+++ b/api-reference/v1.0/api/chartdatalabels-update.md
@@ -103,7 +103,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartfont-get.md
+++ b/api-reference/v1.0/api/chartfont-get.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartfont-update.md
+++ b/api-reference/v1.0/api/chartfont-update.md
@@ -106,7 +106,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartgridlines-get.md
+++ b/api-reference/v1.0/api/chartgridlines-get.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartgridlines-update.md
+++ b/api-reference/v1.0/api/chartgridlines-update.md
@@ -93,7 +93,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartlegend-get.md
+++ b/api-reference/v1.0/api/chartlegend-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartlegend-update.md
+++ b/api-reference/v1.0/api/chartlegend-update.md
@@ -96,7 +96,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartlineformat-get.md
+++ b/api-reference/v1.0/api/chartlineformat-get.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartlineformat-update.md
+++ b/api-reference/v1.0/api/chartlineformat-update.md
@@ -96,7 +96,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartpoint-get.md
+++ b/api-reference/v1.0/api/chartpoint-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartpoint-list.md
+++ b/api-reference/v1.0/api/chartpoint-list.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartpointscollection-itemat.md
+++ b/api-reference/v1.0/api/chartpointscollection-itemat.md
@@ -97,7 +97,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartseries-get.md
+++ b/api-reference/v1.0/api/chartseries-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartseries-list-points.md
+++ b/api-reference/v1.0/api/chartseries-list-points.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartseries-list.md
+++ b/api-reference/v1.0/api/chartseries-list.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartseries-post-points.md
+++ b/api-reference/v1.0/api/chartseries-post-points.md
@@ -87,7 +87,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [ChartPoints](../resources/workbookchartpoint.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartseries-update.md
+++ b/api-reference/v1.0/api/chartseries-update.md
@@ -93,7 +93,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/chartseriescollection-itemat.md
+++ b/api-reference/v1.0/api/chartseriescollection-itemat.md
@@ -97,7 +97,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/charttitle-get.md
+++ b/api-reference/v1.0/api/charttitle-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/charttitle-update.md
+++ b/api-reference/v1.0/api/charttitle-update.md
@@ -96,7 +96,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/contact-delete.md
+++ b/api-reference/v1.0/api/contact-delete.md
@@ -96,7 +96,9 @@ DELETE https://graph.microsoft.com/v1.0/me/contacts/{id}
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/contactfolder-get.md
+++ b/api-reference/v1.0/api/contactfolder-get.md
@@ -91,7 +91,9 @@ GET https://graph.microsoft.com/v1.0/me/contactFolders/{id}
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/contactfolder-list-childfolders.md
+++ b/api-reference/v1.0/api/contactfolder-list-childfolders.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/contactFolders/{id}/childFolders
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/contactfolder-list-contacts.md
+++ b/api-reference/v1.0/api/contactfolder-list-contacts.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/contactFolders/{id}/contacts
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/contactfolder-post-childfolders.md
+++ b/api-reference/v1.0/api/contactfolder-post-childfolders.md
@@ -93,7 +93,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [contactFolder](../resources/contactfolder.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/contactfolder-update.md
+++ b/api-reference/v1.0/api/contactfolder-update.md
@@ -98,7 +98,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/conversationthread-get.md
+++ b/api-reference/v1.0/api/conversationthread-get.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/conversationthread-list-posts.md
+++ b/api-reference/v1.0/api/conversationthread-list-posts.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/device-list-registeredusers.md
+++ b/api-reference/v1.0/api/device-list-registeredusers.md
@@ -101,7 +101,9 @@ GET https://graph.microsoft.com/v1.0/devices/{id}/registeredUsers
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/device-post-devices.md
+++ b/api-reference/v1.0/api/device-post-devices.md
@@ -105,7 +105,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [device](../resources/device.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/device-post-registeredowners.md
+++ b/api-reference/v1.0/api/device-post-registeredowners.md
@@ -95,7 +95,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [directoryObject](../resources/directoryobject.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/v1.0/api/device-post-registeredusers.md
+++ b/api-reference/v1.0/api/device-post-registeredusers.md
@@ -95,7 +95,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [directoryObject](../resources/directoryobject.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/v1.0/api/directoryroletemplate-get.md
+++ b/api-reference/v1.0/api/directoryroletemplate-get.md
@@ -93,7 +93,9 @@ GET https://graph.microsoft.com/v1.0/directoryRoleTemplates/62e90394-69f5-4237-9
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/educationuser-update.md
+++ b/api-reference/v1.0/api/educationuser-update.md
@@ -122,7 +122,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/event-list-attachments.md
+++ b/api-reference/v1.0/api/event-list-attachments.md
@@ -115,7 +115,9 @@ GET https://graph.microsoft.com/v1.0/me/events/AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1hM
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "event_get_attachments_v1",

--- a/api-reference/v1.0/api/event-update.md
+++ b/api-reference/v1.0/api/event-update.md
@@ -174,7 +174,9 @@ Content-type: application/json
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/eventmessage-get.md
+++ b/api-reference/v1.0/api/eventmessage-get.md
@@ -97,7 +97,9 @@ GET https://graph.microsoft.com/v1.0/me/messages/AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1
 ---
 
 #### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "get_eventmessage",

--- a/api-reference/v1.0/api/eventmessage-list-attachments.md
+++ b/api-reference/v1.0/api/eventmessage-list-attachments.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/messages/AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "eventmessage_get_attachments_v1",

--- a/api-reference/v1.0/api/eventmessage-post-attachments.md
+++ b/api-reference/v1.0/api/eventmessage-post-attachments.md
@@ -106,7 +106,9 @@ Content-type: application/json
 In the request body, supply a JSON representation of [attachment](../resources/attachment.md) object.
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/v1.0/api/eventmessage-update.md
+++ b/api-reference/v1.0/api/eventmessage-update.md
@@ -102,7 +102,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/icon-get.md
+++ b/api-reference/v1.0/api/icon-get.md
@@ -55,7 +55,9 @@ The following example shows a request.
 GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|name}/sort/fields/icon
 ```
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/icon-update.md
+++ b/api-reference/v1.0/api/icon-update.md
@@ -65,7 +65,9 @@ Content-type: application/json
 }
 ```
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/inferenceclassification-list-overrides.md
+++ b/api-reference/v1.0/api/inferenceclassification-list-overrides.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/inferenceClassification/overrides
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/inferenceclassification-post-overrides.md
+++ b/api-reference/v1.0/api/inferenceclassification-post-overrides.md
@@ -101,7 +101,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/inferenceclassificationoverride-update.md
+++ b/api-reference/v1.0/api/inferenceclassificationoverride-update.md
@@ -102,7 +102,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/insights-list-trending.md
+++ b/api-reference/v1.0/api/insights-list-trending.md
@@ -110,7 +110,9 @@ GET https://graph.microsoft.com/v1.0/me/insights/trending
 ---
 
 #### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability. See an example un-truncated response at the bottom of the page.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability. See an example un-truncated response at the bottom of the page.
 
 
 <!-- {

--- a/api-reference/v1.0/api/mailfolder-list-childfolders.md
+++ b/api-reference/v1.0/api/mailfolder-list-childfolders.md
@@ -107,7 +107,9 @@ GET https://graph.microsoft.com/v1.0/me/mailFolders/AAMkAGVmMDEzMTM4LTZmYWUtNDdk
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -181,7 +183,9 @@ GET https://graph.microsoft.com/v1.0/me/mailFolders/AAMkAGVmMDEzMTM4LTZmYWUtNDdk
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/mailfolder-list-messages.md
+++ b/api-reference/v1.0/api/mailfolder-list-messages.md
@@ -86,7 +86,9 @@ GET https://graph.microsoft.com/v1.0/me/mailFolders/AAMkAGVmMDEzMTM4LTZmYWUtNDdk
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/mailfolder-post-messagerules.md
+++ b/api-reference/v1.0/api/mailfolder-post-messagerules.md
@@ -123,7 +123,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/mailfolder-post-messages.md
+++ b/api-reference/v1.0/api/mailfolder-post-messages.md
@@ -102,7 +102,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [message](../resources/message.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/mailfolder-update.md
+++ b/api-reference/v1.0/api/mailfolder-update.md
@@ -96,7 +96,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/message-createreply.md
+++ b/api-reference/v1.0/api/message-createreply.md
@@ -110,7 +110,9 @@ POST https://graph.microsoft.com/v1.0/me/messages/{id}/createReply
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/message-createreplyall.md
+++ b/api-reference/v1.0/api/message-createreplyall.md
@@ -108,7 +108,9 @@ POST https://graph.microsoft.com/v1.0/me/messages/{id}/createReplyAll
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/message-get.md
+++ b/api-reference/v1.0/api/message-get.md
@@ -121,7 +121,9 @@ GET https://graph.microsoft.com/v1.0/me/messages/AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1
 ---
 
 #### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "get_message",

--- a/api-reference/v1.0/api/message-list-attachments.md
+++ b/api-reference/v1.0/api/message-list-attachments.md
@@ -101,7 +101,9 @@ GET https://graph.microsoft.com/v1.0/me/messages/AAMkAGVmMDEzMTM4LTZmYWUtNDdkNC1
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "message_get_attachments_v1",

--- a/api-reference/v1.0/api/message-post-attachments.md
+++ b/api-reference/v1.0/api/message-post-attachments.md
@@ -187,7 +187,9 @@ Content-type: application/json
 
 
 #### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "create_item_attachment_from_message_v1",

--- a/api-reference/v1.0/api/message-update.md
+++ b/api-reference/v1.0/api/message-update.md
@@ -122,7 +122,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/messagerule-update.md
+++ b/api-reference/v1.0/api/messagerule-update.md
@@ -109,7 +109,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/nameditem-add.md
+++ b/api-reference/v1.0/api/nameditem-add.md
@@ -102,7 +102,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/nameditem-addformulalocal.md
+++ b/api-reference/v1.0/api/nameditem-addformulalocal.md
@@ -100,7 +100,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/nameditem-get.md
+++ b/api-reference/v1.0/api/nameditem-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/nameditem-list.md
+++ b/api-reference/v1.0/api/nameditem-list.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/nameditem-range.md
+++ b/api-reference/v1.0/api/nameditem-range.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/nameditem-update.md
+++ b/api-reference/v1.0/api/nameditem-update.md
@@ -98,7 +98,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/onenoteoperation-get.md
+++ b/api-reference/v1.0/api/onenoteoperation-get.md
@@ -95,7 +95,9 @@ GET https://graph.microsoft.com/v1.0/me/onenote/operations/{id}
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/opentypeextension-get.md
+++ b/api-reference/v1.0/api/opentypeextension-get.md
@@ -346,7 +346,9 @@ GET https://graph.microsoft.com/v1.0/me/messages/AAMkAGE1M2IyNGNmLTI5MTktNDUyZi1
 
 #### Response 3
 
-And here is the response from the third example. Note: The response object shown here might be shortened for readability.
+And here is the response from the third example.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/organization-get.md
+++ b/api-reference/v1.0/api/organization-get.md
@@ -105,7 +105,9 @@ GET https://graph.microsoft.com/v1.0/organization/dcd219dd-bc68-4b9b-bf0b-4a33a7
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/planner-list-buckets.md
+++ b/api-reference/v1.0/api/planner-list-buckets.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/planner/buckets
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/planner-list-tasks.md
+++ b/api-reference/v1.0/api/planner-list-tasks.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/planner/tasks
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/plannerassignedtotaskboardtaskformat-update.md
+++ b/api-reference/v1.0/api/plannerassignedtotaskboardtaskformat-update.md
@@ -103,7 +103,9 @@ If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/plannerbucket-update.md
+++ b/api-reference/v1.0/api/plannerbucket-update.md
@@ -101,7 +101,9 @@ If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/plannerbuckettaskboardtaskformat-get.md
+++ b/api-reference/v1.0/api/plannerbuckettaskboardtaskformat-get.md
@@ -86,7 +86,9 @@ GET https://graph.microsoft.com/v1.0/planner/tasks/{task-id}/bucketTaskBoardForm
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/plannergroup-list-plans.md
+++ b/api-reference/v1.0/api/plannergroup-list-plans.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/plannerplandetails-update.md
+++ b/api-reference/v1.0/api/plannerplandetails-update.md
@@ -108,7 +108,9 @@ If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/plannerprogresstaskboardtaskformat-get.md
+++ b/api-reference/v1.0/api/plannerprogresstaskboardtaskformat-get.md
@@ -86,7 +86,9 @@ GET https://graph.microsoft.com/v1.0/planner/tasks/{task-id}/progressTaskBoardFo
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/plannerprogresstaskboardtaskformat-update.md
+++ b/api-reference/v1.0/api/plannerprogresstaskboardtaskformat-update.md
@@ -100,7 +100,9 @@ If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/planneruser-list-plans.md
+++ b/api-reference/v1.0/api/planneruser-list-plans.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/planner/plans
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/planneruser-list-tasks.md
+++ b/api-reference/v1.0/api/planneruser-list-tasks.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/planner/tasks
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/post-get.md
+++ b/api-reference/v1.0/api/post-get.md
@@ -89,7 +89,9 @@ GET https://graph.microsoft.com/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/post-list-attachments.md
+++ b/api-reference/v1.0/api/post-list-attachments.md
@@ -97,7 +97,9 @@ GET https://graph.microsoft.com/v1.0/groups/02bd9fd6-8f93-4758-87c3-1fb73740a315
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "post_get_attachments_v1",

--- a/api-reference/v1.0/api/range-boundingrect.md
+++ b/api-reference/v1.0/api/range-boundingrect.md
@@ -66,7 +66,9 @@ Content-type: application/json
 ```
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-cell.md
+++ b/api-reference/v1.0/api/range-cell.md
@@ -91,7 +91,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-column.md
+++ b/api-reference/v1.0/api/range-column.md
@@ -90,7 +90,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-entirecolumn.md
+++ b/api-reference/v1.0/api/range-entirecolumn.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-entirerow.md
+++ b/api-reference/v1.0/api/range-entirerow.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-get.md
+++ b/api-reference/v1.0/api/range-get.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-insert.md
+++ b/api-reference/v1.0/api/range-insert.md
@@ -96,7 +96,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-intersection.md
+++ b/api-reference/v1.0/api/range-intersection.md
@@ -66,7 +66,9 @@ Content-type: application/json
 ```
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-lastcell.md
+++ b/api-reference/v1.0/api/range-lastcell.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-lastcolumn.md
+++ b/api-reference/v1.0/api/range-lastcolumn.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-lastrow.md
+++ b/api-reference/v1.0/api/range-lastrow.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-offsetrange.md
+++ b/api-reference/v1.0/api/range-offsetrange.md
@@ -68,7 +68,9 @@ Content-type: application/json
 ```
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-row.md
+++ b/api-reference/v1.0/api/range-row.md
@@ -68,7 +68,9 @@ Content-type: application/json
 ```
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-update.md
+++ b/api-reference/v1.0/api/range-update.md
@@ -82,7 +82,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/range-usedrange.md
+++ b/api-reference/v1.0/api/range-usedrange.md
@@ -91,7 +91,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/rangeborder-get.md
+++ b/api-reference/v1.0/api/rangeborder-get.md
@@ -64,7 +64,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangeborder-list.md
+++ b/api-reference/v1.0/api/rangeborder-list.md
@@ -64,7 +64,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangeborder-update.md
+++ b/api-reference/v1.0/api/rangeborder-update.md
@@ -78,7 +78,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangebordercollection-itemat.md
+++ b/api-reference/v1.0/api/rangebordercollection-itemat.md
@@ -78,7 +78,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangefill-get.md
+++ b/api-reference/v1.0/api/rangefill-get.md
@@ -64,7 +64,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangefill-update.md
+++ b/api-reference/v1.0/api/rangefill-update.md
@@ -73,7 +73,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/v1.0/api/rangefont-get.md
+++ b/api-reference/v1.0/api/rangefont-get.md
@@ -64,7 +64,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangefont-update.md
+++ b/api-reference/v1.0/api/rangefont-update.md
@@ -80,7 +80,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangeformat-get.md
+++ b/api-reference/v1.0/api/rangeformat-get.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangeformat-list-borders.md
+++ b/api-reference/v1.0/api/rangeformat-list-borders.md
@@ -64,7 +64,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangeformat-post-borders.md
+++ b/api-reference/v1.0/api/rangeformat-post-borders.md
@@ -73,7 +73,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [workbookRangeBorder](../resources/workbookrangeborder.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/rangeformat-update.md
+++ b/api-reference/v1.0/api/rangeformat-update.md
@@ -98,7 +98,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -154,7 +155,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -208,7 +210,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -261,7 +264,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -315,7 +319,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -369,7 +374,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -422,7 +428,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -478,7 +485,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -532,7 +540,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. 
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/rangeformat-update.md
+++ b/api-reference/v1.0/api/rangeformat-update.md
@@ -98,7 +98,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -153,7 +154,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -206,7 +208,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -258,7 +261,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -311,7 +315,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -364,7 +369,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -416,7 +422,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -471,7 +478,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -524,7 +532,8 @@ Content-type: application/json
 ---
 
 ##### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/schemaextension-list.md
+++ b/api-reference/v1.0/api/schemaextension-list.md
@@ -90,7 +90,9 @@ GET https://graph.microsoft.com/v1.0/schemaExtensions?$filter=id%20eq%20'graphle
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/serviceprincipal-list-createdobjects.md
+++ b/api-reference/v1.0/api/serviceprincipal-list-createdobjects.md
@@ -93,7 +93,9 @@ GET https://graph.microsoft.com/v1.0/servicePrincipals/00063ffc-54e9-405d-b8f3-5
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/serviceprincipal-update.md
+++ b/api-reference/v1.0/api/serviceprincipal-update.md
@@ -129,7 +129,9 @@ Content-type: application/json
 
 #### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/v1.0/api/subscribedsku-get.md
+++ b/api-reference/v1.0/api/subscribedsku-get.md
@@ -90,7 +90,9 @@ GET https://graph.microsoft.com/v1.0/subscribedSkus/dcd219dd-bc68-4b9b-bf0b-4a33
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/subscribedsku-list.md
+++ b/api-reference/v1.0/api/subscribedsku-list.md
@@ -103,7 +103,9 @@ GET https://graph.microsoft.com/v1.0/subscribedSkus
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/table-converttorange.md
+++ b/api-reference/v1.0/api/table-converttorange.md
@@ -84,7 +84,9 @@ POST https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|na
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/table-databodyrange.md
+++ b/api-reference/v1.0/api/table-databodyrange.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/table-get.md
+++ b/api-reference/v1.0/api/table-get.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/table-headerrowrange.md
+++ b/api-reference/v1.0/api/table-headerrowrange.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/table-list-columns.md
+++ b/api-reference/v1.0/api/table-list-columns.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/table-list-rows.md
+++ b/api-reference/v1.0/api/table-list-rows.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/table-list.md
+++ b/api-reference/v1.0/api/table-list.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/table-post-columns.md
+++ b/api-reference/v1.0/api/table-post-columns.md
@@ -93,7 +93,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [workbookTableColumn](../resources/workbooktablecolumn.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/table-totalrowrange.md
+++ b/api-reference/v1.0/api/table-totalrowrange.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumn-databodyrange.md
+++ b/api-reference/v1.0/api/tablecolumn-databodyrange.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumn-get.md
+++ b/api-reference/v1.0/api/tablecolumn-get.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumn-headerrowrange.md
+++ b/api-reference/v1.0/api/tablecolumn-headerrowrange.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumn-list.md
+++ b/api-reference/v1.0/api/tablecolumn-list.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumn-range.md
+++ b/api-reference/v1.0/api/tablecolumn-range.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumn-totalrowrange.md
+++ b/api-reference/v1.0/api/tablecolumn-totalrowrange.md
@@ -87,7 +87,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumn-update.md
+++ b/api-reference/v1.0/api/tablecolumn-update.md
@@ -98,7 +98,9 @@ Content-type: application/json
 > If you want to update multiple fields of a column, make **values** a string array in the request. For example: `"values": [["a"], [1], [2], [3]]`.
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumncollection-add.md
+++ b/api-reference/v1.0/api/tablecolumncollection-add.md
@@ -99,7 +99,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablecolumncollection-itemat.md
+++ b/api-reference/v1.0/api/tablecolumncollection-itemat.md
@@ -99,7 +99,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablerow-get.md
+++ b/api-reference/v1.0/api/tablerow-get.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablerow-list.md
+++ b/api-reference/v1.0/api/tablerow-list.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablerow-update.md
+++ b/api-reference/v1.0/api/tablerow-update.md
@@ -94,7 +94,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablerowcollection-add.md
+++ b/api-reference/v1.0/api/tablerowcollection-add.md
@@ -104,7 +104,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablerowcollection-itemat.md
+++ b/api-reference/v1.0/api/tablerowcollection-itemat.md
@@ -96,7 +96,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/tablesort-get.md
+++ b/api-reference/v1.0/api/tablesort-get.md
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables/{id|nam
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/team-clone.md
+++ b/api-reference/v1.0/api/team-clone.md
@@ -128,7 +128,9 @@ Content-Type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/v1.0/api/user-findmeetingtimes.md
+++ b/api-reference/v1.0/api/user-findmeetingtimes.md
@@ -209,7 +209,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here is an example response. Note: The response object shown here might be shortened for readability.
+Here is an example response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-getmailtips.md
+++ b/api-reference/v1.0/api/user-getmailtips.md
@@ -104,7 +104,9 @@ Content-Type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-list-calendarview.md
+++ b/api-reference/v1.0/api/user-list-calendarview.md
@@ -116,7 +116,9 @@ GET https://graph.microsoft.com/v1.0/me/calendarView?startDateTime=2020-01-01T19
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-list-owneddevices.md
+++ b/api-reference/v1.0/api/user-list-owneddevices.md
@@ -94,7 +94,9 @@ GET https://graph.microsoft.com/v1.0/me/ownedDevices
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-list-registereddevices.md
+++ b/api-reference/v1.0/api/user-list-registereddevices.md
@@ -91,7 +91,9 @@ GET https://graph.microsoft.com/v1.0/me/registeredDevices
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-post-calendargroups.md
+++ b/api-reference/v1.0/api/user-post-calendargroups.md
@@ -92,7 +92,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [calendarGroup](../resources/calendargroup.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-post-contactfolders.md
+++ b/api-reference/v1.0/api/user-post-contactfolders.md
@@ -98,7 +98,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [contactFolder](../resources/contactfolder.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-post-contacts.md
+++ b/api-reference/v1.0/api/user-post-contacts.md
@@ -105,7 +105,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-post-messages.md
+++ b/api-reference/v1.0/api/user-post-messages.md
@@ -132,7 +132,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [message](../resources/message.md) object.
 #### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "create_message_from_user",

--- a/api-reference/v1.0/api/user-reminderview.md
+++ b/api-reference/v1.0/api/user-reminderview.md
@@ -70,7 +70,9 @@ GET https://graph.microsoft.com/v1.0/me/reminderView(startDateTime='2017-06-05T1
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/user-update-mailboxsettings.md
+++ b/api-reference/v1.0/api/user-update-mailboxsettings.md
@@ -144,7 +144,9 @@ Content-Type: application/json
 ---
 
 #### Response
-The response includes the updated settings for automatic replies. Note: The response object shown here might be shortened for readability.
+The response includes the updated settings for automatic replies.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "update_mailboxsettings_1",
@@ -255,7 +257,9 @@ Content-Type: application/json
 ---
 
 #### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "name": "update_mailboxsettings_2",

--- a/api-reference/v1.0/api/usersettings-get.md
+++ b/api-reference/v1.0/api/usersettings-get.md
@@ -99,7 +99,9 @@ GET https://graph.microsoft.com/v1.0/me/settings
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/usersettings-update.md
+++ b/api-reference/v1.0/api/usersettings-update.md
@@ -118,7 +118,9 @@ Content-type: application/json
 
 ### Response
 
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbook-list-names.md
+++ b/api-reference/v1.0/api/workbook-list-names.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbook-list-tables.md
+++ b/api-reference/v1.0/api/workbook-list-tables.md
@@ -86,7 +86,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/tables
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbook-list-worksheets.md
+++ b/api-reference/v1.0/api/workbook-list-worksheets.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbook-post-tables.md
+++ b/api-reference/v1.0/api/workbook-post-tables.md
@@ -92,7 +92,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookformatprotection-get.md
+++ b/api-reference/v1.0/api/workbookformatprotection-get.md
@@ -64,7 +64,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/names/{name}/r
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookformatprotection-update.md
+++ b/api-reference/v1.0/api/workbookformatprotection-update.md
@@ -75,7 +75,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookpivottable-get.md
+++ b/api-reference/v1.0/api/workbookpivottable-get.md
@@ -82,7 +82,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/pivo
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookrange-columnsafter.md
+++ b/api-reference/v1.0/api/workbookrange-columnsafter.md
@@ -92,7 +92,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookrange-columnsbefore.md
+++ b/api-reference/v1.0/api/workbookrange-columnsbefore.md
@@ -92,7 +92,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookrange-rowsabove.md
+++ b/api-reference/v1.0/api/workbookrange-rowsabove.md
@@ -92,7 +92,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/workbookrange-rowsbelow.md
+++ b/api-reference/v1.0/api/workbookrange-rowsbelow.md
@@ -92,7 +92,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",
@@ -156,7 +158,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookrange-visibleview.md
+++ b/api-reference/v1.0/api/workbookrange-visibleview.md
@@ -67,7 +67,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookrangeview-itemat.md
+++ b/api-reference/v1.0/api/workbookrangeview-itemat.md
@@ -65,7 +65,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ```
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookrangeview-list-rows.md
+++ b/api-reference/v1.0/api/workbookrangeview-list-rows.md
@@ -60,7 +60,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookrangeview-range.md
+++ b/api-reference/v1.0/api/workbookrangeview-range.md
@@ -61,7 +61,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/rang
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/workbookworksheet-list-pivottables.md
+++ b/api-reference/v1.0/api/workbookworksheet-list-pivottables.md
@@ -82,7 +82,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/pivo
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-cell.md
+++ b/api-reference/v1.0/api/worksheet-cell.md
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-get.md
+++ b/api-reference/v1.0/api/worksheet-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-list-charts.md
+++ b/api-reference/v1.0/api/worksheet-list-charts.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-list-names.md
+++ b/api-reference/v1.0/api/worksheet-list-names.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-list-tables.md
+++ b/api-reference/v1.0/api/worksheet-list-tables.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-list.md
+++ b/api-reference/v1.0/api/worksheet-list.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-post-charts.md
+++ b/api-reference/v1.0/api/worksheet-post-charts.md
@@ -90,7 +90,9 @@ Content-type: application/json
 
 In the request body, supply a JSON representation of [workbookChart](../resources/workbookchart.md) object.
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-post-tables.md
+++ b/api-reference/v1.0/api/worksheet-post-tables.md
@@ -64,7 +64,9 @@ Content-type: application/json
 }
 ```
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-range.md
+++ b/api-reference/v1.0/api/worksheet-range.md
@@ -86,7 +86,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-update.md
+++ b/api-reference/v1.0/api/worksheet-update.md
@@ -95,7 +95,9 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheet-usedrange.md
+++ b/api-reference/v1.0/api/worksheet-usedrange.md
@@ -95,7 +95,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",
@@ -154,7 +156,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/worksheetprotection-get.md
+++ b/api-reference/v1.0/api/worksheetprotection-get.md
@@ -83,7 +83,9 @@ GET https://graph.microsoft.com/v1.0/me/drive/items/{id}/workbook/worksheets/{id
 ---
 
 ### Response
-The following example shows the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+> **Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,


### PR DESCRIPTION
Corrected the formatting of the standard response example disclaimer — the "Note" sentence was inlined with the introductory sentence rather than rendered as a proper Markdown blockquote, reducing its visibility and breaking documentation formatting conventions.