### PR TITLE
Fix note blockquote v1.0

### DIFF
--- a/api-reference/beta/api/contenttype-update.md
+++ b/api-reference/beta/api/contenttype-update.md
@@ -58,7 +58,9 @@ If successful, this method returns a `200 OK` response code and an updated [cont
 ## Example
 
 ### Request
-The following example is a request.
+
+The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",

--- a/api-reference/v1.0/api/security-authoritytemplate-get.md
+++ b/api-reference/v1.0/api/security-authoritytemplate-get.md
@@ -50,7 +50,8 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -93,7 +94,8 @@ GET https://graph.microsoft.com/v1.0/security/labels/authorities/a94af2e3-853b-6
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
 
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {

--- a/api-reference/v1.0/api/security-categorytemplate-delete-subcategories.md
+++ b/api-reference/v1.0/api/security-categorytemplate-delete-subcategories.md
@@ -44,7 +44,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -87,7 +88,9 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/categories/f44dkle55-6ba
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-categorytemplate-delete-subcategories.md
+++ b/api-reference/v1.0/api/security-categorytemplate-delete-subcategories.md
@@ -91,7 +91,6 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/categories/f44dkle55-6ba
 
 The following example shows the response.
 
->
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/security-categorytemplate-get.md
+++ b/api-reference/v1.0/api/security-categorytemplate-get.md
@@ -50,7 +50,8 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -93,7 +94,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/categories/e2c79762-34a9-75
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-categorytemplate-list-subcategories.md
+++ b/api-reference/v1.0/api/security-categorytemplate-list-subcategories.md
@@ -49,7 +49,8 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -92,7 +93,8 @@ GET https://graph.microsoft.com/v1.0/security/labels/categories/{categoryTemplat
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
 
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {

--- a/api-reference/v1.0/api/security-categorytemplate-post-subcategories.md
+++ b/api-reference/v1.0/api/security-categorytemplate-post-subcategories.md
@@ -56,7 +56,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -105,7 +106,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-departmenttemplate-get.md
+++ b/api-reference/v1.0/api/security-departmenttemplate-get.md
@@ -50,7 +50,8 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -93,7 +94,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/departments/11b44677-9f06-c
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-fileplanreferencetemplate-get.md
+++ b/api-reference/v1.0/api/security-fileplanreferencetemplate-get.md
@@ -50,7 +50,8 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -93,7 +94,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/filePlanReferences/b1f7b518
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-delete-authorities.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-authorities.md
@@ -45,7 +45,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -88,7 +89,9 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/authorities/6cf65e55-6ba
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-delete-authorities.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-authorities.md
@@ -92,7 +92,6 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/authorities/6cf65e55-6ba
 
 The following example shows the response.
 
->
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/security-labelsroot-delete-categories.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-categories.md
@@ -92,7 +92,6 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/categories/6cf65e55-6baf
 
 The following example shows the response.
 
->
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/security-labelsroot-delete-categories.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-categories.md
@@ -45,7 +45,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -88,7 +89,9 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/categories/6cf65e55-6baf
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-delete-citations.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-citations.md
@@ -45,7 +45,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -88,7 +89,9 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/citations/6cf65e55-6baf-
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-delete-citations.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-citations.md
@@ -92,7 +92,6 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/citations/6cf65e55-6baf-
 
 The following example shows the response.
 
->
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/security-labelsroot-delete-departments.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-departments.md
@@ -45,7 +45,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -88,7 +89,9 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/departments/6cf65e55-6ba
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-delete-departments.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-departments.md
@@ -92,7 +92,6 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/departments/6cf65e55-6ba
 
 The following example shows the response.
 
->
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/security-labelsroot-delete-fileplanreferences.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-fileplanreferences.md
@@ -92,7 +92,6 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/filePlanReferences/6cf65
 
 The following example shows the response.
 
->
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/security-labelsroot-delete-fileplanreferences.md
+++ b/api-reference/v1.0/api/security-labelsroot-delete-fileplanreferences.md
@@ -45,7 +45,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -88,7 +89,9 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/filePlanReferences/6cf65
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-list-authorities.md
+++ b/api-reference/v1.0/api/security-labelsroot-list-authorities.md
@@ -50,7 +50,8 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -93,7 +94,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/authorities
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-list-categories.md
+++ b/api-reference/v1.0/api/security-labelsroot-list-categories.md
@@ -49,7 +49,8 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -92,7 +93,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/categories
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-list-citations.md
+++ b/api-reference/v1.0/api/security-labelsroot-list-citations.md
@@ -49,7 +49,8 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -92,7 +93,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/citations
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-list-departments.md
+++ b/api-reference/v1.0/api/security-labelsroot-list-departments.md
@@ -49,7 +49,8 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -92,7 +93,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/departments
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-list-fileplanreferences.md
+++ b/api-reference/v1.0/api/security-labelsroot-list-fileplanreferences.md
@@ -49,7 +49,8 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -92,7 +93,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/filePlanReferences
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-list-retentionlabel.md
+++ b/api-reference/v1.0/api/security-labelsroot-list-retentionlabel.md
@@ -55,7 +55,9 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -97,7 +99,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/retentionLabels
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-post-authorities.md
+++ b/api-reference/v1.0/api/security-labelsroot-post-authorities.md
@@ -56,7 +56,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -105,7 +106,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-post-categories.md
+++ b/api-reference/v1.0/api/security-labelsroot-post-categories.md
@@ -56,7 +56,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -105,7 +106,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-post-citations.md
+++ b/api-reference/v1.0/api/security-labelsroot-post-citations.md
@@ -56,7 +56,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -107,7 +108,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-post-departments.md
+++ b/api-reference/v1.0/api/security-labelsroot-post-departments.md
@@ -56,7 +56,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -105,7 +106,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-post-fileplanreferences.md
+++ b/api-reference/v1.0/api/security-labelsroot-post-fileplanreferences.md
@@ -56,7 +56,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -105,7 +106,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-labelsroot-post-retentionlabel.md
+++ b/api-reference/v1.0/api/security-labelsroot-post-retentionlabel.md
@@ -66,7 +66,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -145,6 +146,7 @@ Content-length: 555
 ---
 
 ### Response
+
 The following example shows the response.
 
 >**Note:** The response object shown here might be shortened for readability.

--- a/api-reference/v1.0/api/security-retentionlabel-delete.md
+++ b/api-reference/v1.0/api/security-retentionlabel-delete.md
@@ -94,7 +94,6 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/retentionLabels/9563a605
 
 The following example shows the response.
 
->
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/v1.0/api/security-retentionlabel-delete.md
+++ b/api-reference/v1.0/api/security-retentionlabel-delete.md
@@ -47,7 +47,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -90,7 +91,9 @@ DELETE https://graph.microsoft.com/v1.0/security/labels/retentionLabels/9563a605
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-retentionlabel-get.md
+++ b/api-reference/v1.0/api/security-retentionlabel-get.md
@@ -50,7 +50,8 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -93,7 +94,9 @@ GET  https://graph.microsoft.com/v1.0/security/labels/retentionLabels/{retention
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/security-retentionlabel-update.md
+++ b/api-reference/v1.0/api/security-retentionlabel-update.md
@@ -62,7 +62,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -115,7 +116,8 @@ Content-length: 555
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
 
 <!-- {
   "blockType": "response"

--- a/api-reference/v1.0/api/security-subcategorytemplate-get.md
+++ b/api-reference/v1.0/api/security-subcategorytemplate-get.md
@@ -49,7 +49,8 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -92,7 +93,9 @@ GET https://graph.microsoft.com/v1.0/security/labels/categories/82d00422-1f60-46
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",


### PR DESCRIPTION
Replaced "Here's an example of a request." with "The following example shows a request." and "Here's an example of the response." with "The following example shows the response."