### PR TITLE
docs: Add onPremisesExtensionAttributes property to group resource (v1.0)

### DIFF
--- a/api-reference/v1.0/resources/group.md
+++ b/api-reference/v1.0/resources/group.md
@@ -6,7 +6,7 @@ author: "yuhko-msft"
 ms.reviewer: "mbhargav, khotzteam, aadgroupssg"
 ms.subservice: "entra-groups"
 doc_type: resourcePageType
-ms.date: 10/17/2024
+ms.date: 05/21/2026
 ---
 
 # group resource type
@@ -159,6 +159,7 @@ This resource supports:
 | membershipRule | String | The rule that determines members for this group if the group is a dynamic group (groupTypes contains `DynamicMembership`). For more information about the syntax of the membership rule, see [Membership Rules syntax](/azure/active-directory/users-groups-roles/groups-dynamic-membership). <br><br>Returned by default. Supports `$filter` (`eq`, `ne`, `not`, `ge`, `le`, `startsWith`). |
 | membershipRuleProcessingState | String | Indicates whether the dynamic membership processing is on or paused. Possible values are `On` or `Paused`. <br><br>Returned by default. Supports `$filter` (`eq`, `ne`, `not`, `in`). |
 | onPremisesDomainName | String | Contains the on-premises **domain FQDN**, also called **dnsDomainName** synchronized from the on-premises directory. The property is only populated for customers synchronizing their on-premises directory to Microsoft Entra ID via Microsoft Entra Connect.<br><br>Returned by default. Read-only. |
+| onPremisesExtensionAttributes | [onPremisesExtensionAttributes](onpremisesextensionattributes.md) | Contains extensionAttributes1-15 for the group. These extension attributes are also known as Exchange custom attributes 1-15. <br><br>Returned only on `$select`. Supports `$filter` (`eq`, `ne`, `not`, `in`). |
 | onPremisesLastSyncDateTime | DateTimeOffset | Indicates the last time at which the group was synced with the on-premises directory. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on January 1, 2014 is `2014-01-01T00:00:00Z`. <br><br>Returned by default. Read-only. Supports `$filter` (`eq`, `ne`, `not`, `ge`, `le`, `in`). |
 | onPremisesNetBiosName | String | Contains the on-premises **netBios name** synchronized from the on-premises directory. The property is only populated for customers synchronizing their on-premises directory to Microsoft Entra ID via Microsoft Entra Connect.<br><br>Returned by default. Read-only. |
 | onPremisesProvisioningErrors | [onPremisesProvisioningError](onpremisesprovisioningerror.md) collection | Errors when using Microsoft synchronization product during provisioning. <br><br>Returned by default. Supports `$filter` (`eq`, `not`). |
@@ -391,6 +392,7 @@ The following JSON representation shows the resource type.
   "members": [{ "@odata.type": "microsoft.graph.directoryObject" }],
   "membersWithLicenseErrors": [{ "@odata.type": "microsoft.graph.user" }],
   "onPremisesDomainName": "String",
+  "onPremisesExtensionAttributes": { "@odata.type": "microsoft.graph.onPremisesExtensionAttributes" },
   "onPremisesLastSyncDateTime": "String (timestamp)",
   "onPremisesNetBiosName": "String",
   "onPremisesProvisioningErrors": [

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -3,6 +3,24 @@
     {
       "ChangeList": [
         {
+          "Id": "a3f7c2e1-8d4b-4a91-b6e0-2c5d9f1a7b3e",
+          "ApiChange": "Property",
+          "ChangedApiName": "onPremisesExtensionAttributes",
+          "ChangeType": "Addition",
+          "Description": "Added the **onPremisesExtensionAttributes** property to the [group](https://learn.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-1.0) resource.",
+          "Target": "group"
+        }
+      ],
+      "Id": "a3f7c2e1-8d4b-4a91-b6e0-2c5d9f1a7b3e",
+      "Cloud": "Prod",
+      "Version": "v1.0",
+      "CreatedDateTime": "2026-05-21T21:22:00.0000000Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Directory management"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "b18a7db8-92de-4d28-b025-71d5d3fc511a",
           "ApiChange": "Enumeration",
           "ChangedApiName": "customSecurityAttributeComparisonOperator",


### PR DESCRIPTION
## Summary

Adds the **onPremisesExtensionAttributes** property to the [group](https://learn.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-1.0) resource documentation for v1.0.

This is the v1.0 counterpart to the beta addition that was previously merged.

## Changes
- **api-reference/v1.0/resources/group.md**: Added onPremisesExtensionAttributes to the properties table and JSON representation
- **changelog/Microsoft.DirectoryServices.json**: Added changelog entry for the v1.0 property addition

## Related
- ADO PR: https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/15745606
