### PR TITLE
docs: Add disableNesting property to group resource (beta)

### DIFF
--- a/api-reference/beta/resources/group.md
+++ b/api-reference/beta/resources/group.md
@@ -6,7 +6,7 @@ author: "yuhko-msft"
 ms.reviewer: "mbhargav, khotzteam, aadgroupssg"
 ms.subservice: "entra-groups"
 doc_type: resourcePageType
-ms.date: 10/04/2024
+ms.date: 05/21/2026
 ---
 
 # group resource type
@@ -160,6 +160,7 @@ name. |
 | createdDateTime | DateTimeOffset | Timestamp of when the group was created. The value can't be modified and is automatically populated when the group is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. <br><br>Returned by default. Read-only. |
 | deletedDateTime | DateTimeOffset | For some Microsoft Entra objects (user, group, application), if the object is deleted, it is first logically deleted, and this property is updated with the date and time when the object was deleted. Otherwise this property is null. If the object is restored, this property is updated to `null`. Inherited from [directoryObject](../resources/directoryobject.md). |
 | description | String | An optional description for the group. <br><br>Returned by default. Supports `$filter` (`eq`, `ne`, `not`, `ge`, `le`, `startsWith`) and `$search`. |
+| disableNesting | Boolean | Indicates whether other groups can be added as members of this group. When set to `true`, no group can be added as a member. Default value is `false`. Read/write, but read-only on Microsoft 365 groups and groups with **isAssignableToRole** set to `true`. <br><br>Supports `$filter` (`eq`, `ne`, `not`). Requires `$select` to retrieve. |
 | displayName | String | The display name for the group. Required. Maximum length is 256 characters. <br><br>Returned by default. Supports `$filter` (`eq`, `ne`, `not`, `ge`, `le`, `in`, `startsWith`, and `eq` on `null` values), `$search`, and `$orderby`. |
 | expirationDateTime | DateTimeOffset | Timestamp of when the group is set to expire. It is `null` for security groups, but for Microsoft 365 groups, it represents when the group is set to expire as defined in the [groupLifecyclePolicy](../resources/grouplifecyclepolicy.md). The Timestamp type represents date and time information using ISO 8601 format and is always in UTC. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. <br><br>Returned by default. Supports `$filter` (`eq`, `ne`, `not`, `ge`, `le`, `in`). Read-only. |
 | groupTypes | String collection | Specifies the group type and its membership. <br><br>If the collection contains `Unified`, the group is a Microsoft 365 group; otherwise, it's either a security group or a distribution group. For details, see [groups overview](groups-overview.md).<br><br>If the collection includes `DynamicMembership`, the group has dynamic membership; otherwise, membership is static. <br><br>Returned by default. Supports `$filter` (`eq`, `not`). |
@@ -305,6 +306,7 @@ The following JSON representation shows the resource type.
   "createdDateTime": "String (timestamp)",
   "deletedDateTime": "String (timestamp)",
   "description": "String",
+  "disableNesting": "Boolean",
   "displayName": "String",
   "expirationDateTime": "String (timestamp)",
   "groupTypes": ["String"],

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -3,6 +3,24 @@
     {
       "ChangeList": [
         {
+          "Id": "d7e2f4a1-3c6b-49d8-a1f5-8b4c2e7d9a0f",
+          "ApiChange": "Property",
+          "ChangedApiName": "disableNesting",
+          "ChangeType": "Addition",
+          "Description": "Added the **disableNesting** property to the [group](https://learn.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-beta) resource.",
+          "Target": "group"
+        }
+      ],
+      "Id": "d7e2f4a1-3c6b-49d8-a1f5-8b4c2e7d9a0f",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-05-21T21:30:00.0000000Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Directory management"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "b18a7db8-92de-4d28-b025-71d5d3fc511a",
           "ApiChange": "Enumeration",
           "ChangedApiName": "customSecurityAttributeComparisonOperator",


### PR DESCRIPTION
## Summary

Adds the **disableNesting** Boolean property to the [group](https://learn.microsoft.com/en-us/graph/api/resources/group?view=graph-rest-beta) resource documentation for beta.

This property controls whether other groups can be added as members of the group:
- **Type:** Boolean (non-nullable, default \alse\)
- **Read/write**, but read-only on Microsoft 365 (Unified) groups and groups with \isAssignableToRole = true\
- Requires \\\ to retrieve

## Changes
- **api-reference/beta/resources/group.md**: Added disableNesting to the properties table and JSON representation
- **changelog/Microsoft.DirectoryServices.json**: Added changelog entry for the beta property addition

## Related
- ADO PR: https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/15632295
