### PR TITLE
Remove RBAC roles section from directory-deleteditems-list and get APIs

### DIFF
--- a/api-reference/beta/api/directory-deleteditems-get.md
+++ b/api-reference/beta/api/directory-deleteditems-get.md
@@ -51,8 +51,6 @@ The following table shows the least privileged permission or permissions require
 | [certificateBasedAuthPki](../resources/certificatebasedauthpki.md) | PublicKeyInfrastructure.Read.All | Not supported. | PublicKeyInfrastructure.Read.All |
 | [certificateAuthorityDetail](../resources/certificateauthoritydetail.md) | PublicKeyInfrastructure.Read.All | Not supported. | PublicKeyInfrastructure.Read.All |
 
-[!INCLUDE [rbac-directory-deleted-items-apis](../includes/rbac-for-apis/rbac-directory-deleted-items-apis.md)]
-
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http

--- a/api-reference/beta/api/directory-deleteditems-list.md
+++ b/api-reference/beta/api/directory-deleteditems-list.md
@@ -53,8 +53,6 @@ The following table shows the least privileged permission or permissions require
 
 [!INCLUDE [limited-info](../../includes/limited-info.md)]
 
-[!INCLUDE [rbac-directory-deleted-items-apis](../includes/rbac-for-apis/rbac-directory-deleted-items-apis.md)]
-
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http 

--- a/api-reference/v1.0/api/directory-deleteditems-get.md
+++ b/api-reference/v1.0/api/directory-deleteditems-get.md
@@ -45,8 +45,6 @@ The following table shows the least privileged permission or permissions require
 | [certificateBasedAuthPki](../resources/certificatebasedauthpki.md) | PublicKeyInfrastructure.Read.All | Not supported. | PublicKeyInfrastructure.Read.All |
 | [certificateAuthorityDetail](../resources/certificateauthoritydetail.md) | PublicKeyInfrastructure.Read.All | Not supported. | PublicKeyInfrastructure.Read.All |
 
-[!INCLUDE [rbac-directory-deleted-items-apis](../includes/rbac-for-apis/rbac-directory-deleted-items-apis.md)]
-
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http

--- a/api-reference/v1.0/api/directory-deleteditems-list.md
+++ b/api-reference/v1.0/api/directory-deleteditems-list.md
@@ -47,8 +47,6 @@ The following table shows the least privileged permission or permissions require
 
 [!INCLUDE [limited-info](../../includes/limited-info.md)]
 
-[!INCLUDE [rbac-directory-deleted-items-apis](../includes/rbac-for-apis/rbac-directory-deleted-items-apis.md)]
-
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http 


### PR DESCRIPTION
## Summary

Remove the `[!INCLUDE]` reference to `rbac-directory-deleted-items-apis.md` from the following pages:

- `api-reference/v1.0/api/directory-deleteditems-list.md`
- `api-reference/v1.0/api/directory-deleteditems-get.md`
- `api-reference/beta/api/directory-deleteditems-list.md`
- `api-reference/beta/api/directory-deleteditems-get.md`

This removes the **Important** note about supported Microsoft Entra built-in roles (Agent ID Administrator, Directory Readers, Application Administrator, etc.) from these specific API documentation pages.

## Changes

Removed the include line that renders the RBAC roles callout on these 4 pages. The include file itself is left intact for other pages that still reference it.