### PR TITLE
Fix note blockquote beta

### DIFF
--- a/api-reference/beta/api/networkaccess-remotenetwork-get.md
+++ b/api-reference/beta/api/networkaccess-remotenetwork-get.md
@@ -57,14 +57,17 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 ```http
 GET https://graph.microsoft.com/beta/networkAccess/connectivity/remoteNetworks/dc6a7efd-6b2b-4c6a-84e7-5dcf97e62e04
 ```
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-authoritytemplate-get.md
+++ b/api-reference/beta/api/security-authoritytemplate-get.md
@@ -52,7 +52,9 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -94,7 +96,9 @@ GET https://graph.microsoft.com/beta/security/labels/authorities/6cf65e55-6baf-4
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-categorytemplate-delete-subcategories.md
+++ b/api-reference/beta/api/security-categorytemplate-delete-subcategories.md
@@ -46,7 +46,9 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -88,7 +90,9 @@ DELETE https://graph.microsoft.com/beta/security/labels/categories/6cf65e55-6baf
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-categorytemplate-get.md
+++ b/api-reference/beta/api/security-categorytemplate-get.md
@@ -52,7 +52,9 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -94,7 +96,9 @@ GET https://graph.microsoft.com/beta/security/labels/categories/e2c79762-34a9-75
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-categorytemplate-post-subcategories.md
+++ b/api-reference/beta/api/security-categorytemplate-post-subcategories.md
@@ -57,7 +57,9 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -105,7 +107,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-departmenttemplate-get.md
+++ b/api-reference/beta/api/security-departmenttemplate-get.md
@@ -52,7 +52,9 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -94,7 +96,9 @@ GET https://graph.microsoft.com/beta/security/labels/departments/11b44677-9f06-c
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-delete-authorities.md
+++ b/api-reference/beta/api/security-labelsroot-delete-authorities.md
@@ -49,7 +49,9 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -91,7 +93,9 @@ DELETE https://graph.microsoft.com/beta/security/labels/authorities/f44dkle55-6b
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-delete-categories.md
+++ b/api-reference/beta/api/security-labelsroot-delete-categories.md
@@ -49,7 +49,9 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -91,7 +93,9 @@ DELETE https://graph.microsoft.com/beta/security/labels/categories/f44dkle55-6ba
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-delete-citations.md
+++ b/api-reference/beta/api/security-labelsroot-delete-citations.md
@@ -49,7 +49,9 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -94,7 +96,9 @@ DELETE https://graph.microsoft.com/beta/security/labels/citations/f44dkle55-6baf
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-delete-departments.md
+++ b/api-reference/beta/api/security-labelsroot-delete-departments.md
@@ -49,7 +49,9 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -91,7 +93,9 @@ DELETE https://graph.microsoft.com/beta/security/labels/departments/f44dkle55-6b
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-delete-fileplanreferences.md
+++ b/api-reference/beta/api/security-labelsroot-delete-fileplanreferences.md
@@ -49,7 +49,9 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -91,7 +93,9 @@ DELETE https://graph.microsoft.com/beta/security/labels/filePlanReferences/f44dk
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-list-authorities.md
+++ b/api-reference/beta/api/security-labelsroot-list-authorities.md
@@ -51,7 +51,9 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -93,7 +95,9 @@ GET https://graph.microsoft.com/beta/security/labels/authorities
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-list-categories.md
+++ b/api-reference/beta/api/security-labelsroot-list-categories.md
@@ -51,7 +51,9 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -93,7 +95,9 @@ GET https://graph.microsoft.com/beta/security/labels/categories
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-list-citations.md
+++ b/api-reference/beta/api/security-labelsroot-list-citations.md
@@ -51,7 +51,9 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -93,7 +95,9 @@ GET https://graph.microsoft.com/beta/security/labels/citations
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-list-departments.md
+++ b/api-reference/beta/api/security-labelsroot-list-departments.md
@@ -51,7 +51,9 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -93,7 +95,9 @@ GET https://graph.microsoft.com/beta/security/labels/departments
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-list-fileplanreferences.md
+++ b/api-reference/beta/api/security-labelsroot-list-fileplanreferences.md
@@ -51,7 +51,9 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -93,7 +95,9 @@ GET https://graph.microsoft.com/beta/security/labels/filePlanReferences
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-list-retentionlabel.md
+++ b/api-reference/beta/api/security-labelsroot-list-retentionlabel.md
@@ -57,7 +57,9 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -99,7 +101,9 @@ GET https://graph.microsoft.com/beta/security/labels/retentionLabels
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-post-authorities.md
+++ b/api-reference/beta/api/security-labelsroot-post-authorities.md
@@ -58,7 +58,9 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -106,7 +108,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-post-categories.md
+++ b/api-reference/beta/api/security-labelsroot-post-categories.md
@@ -58,7 +58,9 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -106,7 +108,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-post-citations.md
+++ b/api-reference/beta/api/security-labelsroot-post-citations.md
@@ -58,7 +58,9 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -108,7 +110,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-post-departments.md
+++ b/api-reference/beta/api/security-labelsroot-post-departments.md
@@ -58,7 +58,9 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -106,7 +108,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-post-fileplanreferences.md
+++ b/api-reference/beta/api/security-labelsroot-post-fileplanreferences.md
@@ -58,7 +58,9 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -106,7 +108,9 @@ Content-Type: application/json
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-labelsroot-post-retentionlabel.md
+++ b/api-reference/beta/api/security-labelsroot-post-retentionlabel.md
@@ -68,7 +68,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -145,7 +146,9 @@ Content-length: 555
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-retentionevent-get.md
+++ b/api-reference/beta/api/security-retentionevent-get.md
@@ -51,7 +51,9 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -93,7 +95,9 @@ GET https://graph.microsoft.com/beta/security/triggers/retentionEvents/{retentio
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-retentionevent-list.md
+++ b/api-reference/beta/api/security-retentionevent-list.md
@@ -96,7 +96,7 @@ GET https://graph.microsoft.com/beta/security/triggers/retentionEvents
 
 ### Response
 
-The following example shows a request.
+The following example shows the response.
 
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {

--- a/api-reference/beta/api/security-retentionevent-list.md
+++ b/api-reference/beta/api/security-retentionevent-list.md
@@ -51,7 +51,8 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -94,7 +95,9 @@ GET https://graph.microsoft.com/beta/security/triggers/retentionEvents
 ---
 
 ### Response
-Here's an example of a request.
+
+The following example shows a request.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-retentionevent-post.md
+++ b/api-reference/beta/api/security-retentionevent-post.md
@@ -59,7 +59,8 @@ If successful, this method returns a `201 Created` response code and a [microsof
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -128,7 +129,9 @@ Content-length: 616
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-retentionlabel-delete.md
+++ b/api-reference/beta/api/security-retentionlabel-delete.md
@@ -49,7 +49,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -92,7 +93,8 @@ DELETE https://graph.microsoft.com/beta/security/labels/retentionLabels/9563a605
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
 
 >
 <!-- {

--- a/api-reference/beta/api/security-retentionlabel-get.md
+++ b/api-reference/beta/api/security-retentionlabel-get.md
@@ -52,7 +52,8 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -95,7 +96,9 @@ GET  https://graph.microsoft.com/beta/security/labels/retentionLabels/{retention
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/security-retentionlabel-update.md
+++ b/api-reference/beta/api/security-retentionlabel-update.md
@@ -64,7 +64,8 @@ If successful, this method returns a `204 No Content` response code.
 ## Examples
 
 ### Request
-Here's an example of a request.
+
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -117,7 +118,8 @@ Content-length: 555
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
 
 <!-- {
   "blockType": "response"

--- a/api-reference/beta/api/security-subcategorytemplate-get.md
+++ b/api-reference/beta/api/security-subcategorytemplate-get.md
@@ -51,7 +51,9 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
+
 The following example shows a request.
+
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -93,7 +95,9 @@ GET https://graph.microsoft.com/beta/security/labels/categories/82d00422-1f60-46
 ---
 
 ### Response
-Here's an example of the response.
+
+The following example shows the response.
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",


### PR DESCRIPTION
Replaced "Here's an example of a request." with "The following example shows a request." and "Here's an example of the response." with "The following example shows the response."