### PR TITLE
Add groupDisplayName property to delegatedAdministrationRoleAssignment(Snapshot)

### DIFF
--- a/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
+++ b/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
@@ -20,7 +20,7 @@ Represents a role assignment configuration for delegated administration in a gov
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|groupName|String|The display name of the security group referenced by the **group** navigation property. Read-only.|
+|groupDisplayName|String|The display name of the security group referenced by the **group** navigation property, captured when the policy template is created or updated. The value is not refreshed automatically when the underlying group is renamed; it is refreshed only the next time the policy template is updated. Read-only.|
 |roleTemplates|[microsoft.graph.tenantGovernanceServices.roleTemplate](../resources/tenantgovernanceservices-roletemplate.md) collection|A collection of role templates that define the roles to be assigned to the group in the governed tenant. |
 
 ## Relationships
@@ -38,7 +38,7 @@ The following JSON representation shows the resource type.
 ``` json
 {
   "@odata.type": "#microsoft.graph.tenantGovernanceServices.delegatedAdministrationRoleAssignment",
-  "groupName": "String",
+  "groupDisplayName": "String",
   "roleTemplates": [
     {
       "@odata.type": "microsoft.graph.tenantGovernanceServices.roleTemplate"

--- a/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
+++ b/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
@@ -20,6 +20,7 @@ Represents a role assignment configuration for delegated administration in a gov
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
+|groupName|String|The display name of the security group referenced by the **group** navigation property. Read-only.|
 |roleTemplates|[microsoft.graph.tenantGovernanceServices.roleTemplate](../resources/tenantgovernanceservices-roletemplate.md) collection|A collection of role templates that define the roles to be assigned to the group in the governed tenant. |
 
 ## Relationships
@@ -37,6 +38,7 @@ The following JSON representation shows the resource type.
 ``` json
 {
   "@odata.type": "#microsoft.graph.tenantGovernanceServices.delegatedAdministrationRoleAssignment",
+  "groupName": "String",
   "roleTemplates": [
     {
       "@odata.type": "microsoft.graph.tenantGovernanceServices.roleTemplate"

--- a/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
+++ b/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
@@ -20,7 +20,7 @@ Represents a role assignment configuration for delegated administration in a gov
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|groupDisplayName|String|The display name of the security group referenced by the **group** navigation property at the time the parent governance policy was last created or updated. Read-only.|
+|groupDisplayName|String|The display name of the security group referenced by the **group** navigation property at the time the policy template was created or updated. Read-only.|
 |roleTemplates|[microsoft.graph.tenantGovernanceServices.roleTemplate](../resources/tenantgovernanceservices-roletemplate.md) collection|A collection of role templates that define the roles to be assigned to the group in the governed tenant. |
 
 ## Relationships

--- a/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
+++ b/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
@@ -20,7 +20,7 @@ Represents a role assignment configuration for delegated administration in a gov
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|groupDisplayName|String|The display name of the security group referenced by the **group** navigation property at the time the policy template was created or updated. Read-only.|
+|groupDisplayName|String|The display name of the security group referenced by the **group** navigation property at the time the parent governance policy was last created or updated. Read-only.|
 |roleTemplates|[microsoft.graph.tenantGovernanceServices.roleTemplate](../resources/tenantgovernanceservices-roletemplate.md) collection|A collection of role templates that define the roles to be assigned to the group in the governed tenant. |
 
 ## Relationships

--- a/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
+++ b/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignment.md
@@ -20,7 +20,7 @@ Represents a role assignment configuration for delegated administration in a gov
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|groupDisplayName|String|The display name of the security group referenced by the **group** navigation property, captured when the policy template is created or updated. The value is not refreshed automatically when the underlying group is renamed; it is refreshed only the next time the policy template is updated. Read-only.|
+|groupDisplayName|String|The display name of the security group referenced by the **group** navigation property at the time the policy template was created or updated. Read-only.|
 |roleTemplates|[microsoft.graph.tenantGovernanceServices.roleTemplate](../resources/tenantgovernanceservices-roletemplate.md) collection|A collection of role templates that define the roles to be assigned to the group in the governed tenant. |
 
 ## Relationships

--- a/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignmentsnapshot.md
+++ b/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignmentsnapshot.md
@@ -20,7 +20,7 @@ Represents a snapshot of a delegated administration role assignment configuratio
 |Property|Type|Description|
 |:---|:---|:---|
 |groupId|String|The object ID of the role-assignable security group in the governing tenant that will be assigned the specified roles.|
-|groupName|String|The display name of the security group identified by **groupId** at the time the snapshot was created. Read-only.|
+|groupDisplayName|String|The display name of the security group identified by **groupId** at the time the snapshot was created. Read-only.|
 |roleTemplates|[microsoft.graph.tenantGovernanceServices.roleTemplate](../resources/tenantgovernanceservices-roletemplate.md) collection|The collection of role templates that define the Microsoft Entra roles to be assigned.|
 
 ## Relationships
@@ -37,7 +37,7 @@ The following JSON representation shows the resource type.
 {
   "@odata.type": "#microsoft.graph.tenantGovernanceServices.delegatedAdministrationRoleAssignmentSnapshot",
   "groupId": "String",
-  "groupName": "String",
+  "groupDisplayName": "String",
   "roleTemplates": [
     {
       "@odata.type": "microsoft.graph.tenantGovernanceServices.roleTemplate"

--- a/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignmentsnapshot.md
+++ b/api-reference/beta/resources/tenantgovernanceservices-delegatedadministrationroleassignmentsnapshot.md
@@ -20,6 +20,7 @@ Represents a snapshot of a delegated administration role assignment configuratio
 |Property|Type|Description|
 |:---|:---|:---|
 |groupId|String|The object ID of the role-assignable security group in the governing tenant that will be assigned the specified roles.|
+|groupName|String|The display name of the security group identified by **groupId** at the time the snapshot was created. Read-only.|
 |roleTemplates|[microsoft.graph.tenantGovernanceServices.roleTemplate](../resources/tenantgovernanceservices-roletemplate.md) collection|The collection of role templates that define the Microsoft Entra roles to be assigned.|
 
 ## Relationships
@@ -36,6 +37,7 @@ The following JSON representation shows the resource type.
 {
   "@odata.type": "#microsoft.graph.tenantGovernanceServices.delegatedAdministrationRoleAssignmentSnapshot",
   "groupId": "String",
+  "groupName": "String",
   "roleTemplates": [
     {
       "@odata.type": "microsoft.graph.tenantGovernanceServices.roleTemplate"


### PR DESCRIPTION
Adds the new `groupDisplayName` property to two resource types in the tenantGovernanceServices namespace:

- `delegatedAdministrationRoleAssignment`
- `delegatedAdministrationRoleAssignmentSnapshot`

## Summary

This property surfaces the display name of the security group inline, so consumers don't need a separate Microsoft Graph `/groups/{id}` call to resolve it. The property is read-only / server-populated.

## Source of truth

- Beta Schema/ API review approved in: [AGS-Workloads PR 15246447](https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/15875707)
- API Review file: https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads?path=/Reviews/15246447-45725-Add-GDAP-Group-Name/API.md&version=GC286165dd331ad6dad90eadebc8c377897556b495&_a=preview
- PROD/PPE schema [AGS-Workloads PR](https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/15875707)
- TGov service-side implementation: [ID-IAM-TenantGovernance PR 15874506](https://msazure.visualstudio.com/One/_git/ID-IAM-TenantGovernance/pullrequest/15874506)

## Internal contact

- PM: Hannah Fowler (hafowler)
- Eng: Cesar Younes (ceyounes)
