### PR TITLE
Fix missing closing codeblock beta

### DIFF
--- a/api-reference/beta/api/accesspackageresource-list-uploadsessions.md
+++ b/api-reference/beta/api/accesspackageresource-list-uploadsessions.md
@@ -56,8 +56,7 @@ This method supports the `$expand`, `$filter`, `$top`, `$skip`, `$orderby`, `$co
 The **name**, **size**, and **uploadedDateTime** proeprties also support `$orderby` as shown in the following examples: 
 
 Get upload session with files sorted by **uploadedDateTime**:
-```http
-Get upload session with files sorted by **uploadedDateTime**:
+
 ```http
 GET /identityGovernance/entitlementManagement/catalogs/{catalogId}/accessPackageResources/{resourceId}/uploadSessions/{sessionId}?$expand=files($orderby=uploadedDateTime desc)
 ```

--- a/api-reference/beta/api/security-labelsroot-delete-citations.md
+++ b/api-reference/beta/api/security-labelsroot-delete-citations.md
@@ -61,6 +61,8 @@ The following example shows a request.
 ```http
 DELETE https://graph.microsoft.com/beta/security/labels/citations/f44dkle55-6baf-44ff-5dcc-08d8de97b1d5
 
+```
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/delete-citationtemplate-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/beta/api/security-labelsroot-delete-citations.md
+++ b/api-reference/beta/api/security-labelsroot-delete-citations.md
@@ -60,7 +60,6 @@ The following example shows a request.
 -->
 ```http
 DELETE https://graph.microsoft.com/beta/security/labels/citations/f44dkle55-6baf-44ff-5dcc-08d8de97b1d5
-
 ```
 
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/singlevaluelegacyextendedproperty-get.md
+++ b/api-reference/beta/api/singlevaluelegacyextendedproperty-get.md
@@ -297,6 +297,8 @@ Get a **mailboxFolder** instance:
 ```http
 GET /admin/exchange/mailboxes/{mailboxId}/folders?$filter=singleValueExtendedProperties/Any(ep: ep/id eq '{id_value}' and ep/value eq '{property_value}')
 GET /admin/exchange/mailboxes/{mailboxId}/folders/{mailboxFolderId}?$filter=singleValueExtendedProperties/Any(ep: ep/id eq '{id_value}' and ep/value eq '{property_value}')
+```
+
 Get **note** instances:
 <!-- { "blockType": "ignored" } -->
 ```http

--- a/api-reference/beta/api/usersettings-list-windows.md
+++ b/api-reference/beta/api/usersettings-list-windows.md
@@ -39,7 +39,7 @@ For a specific user:
 -->
 ```http
 GET /users/{user-id}@{tenant-id}/settings/windows
-````
+```
 
 > [!NOTE]
 > The `{tenant-id}` value must match the tenant ID of the calling user. To find your tenant ID, see [How to find your Microsoft Entra tenant ID](/entra/fundamentals/how-to-find-tenant).

--- a/api-reference/beta/api/webapplicationfirewallprovider-verify.md
+++ b/api-reference/beta/api/webapplicationfirewallprovider-verify.md
@@ -191,6 +191,8 @@ Content-Type: application/json
 {
     "hostName": "www.contoso.com"
 }
+```
+
 #### Response
 
 The following example shows the response.

--- a/api-reference/beta/api/windowssetting-get.md
+++ b/api-reference/beta/api/windowssetting-get.md
@@ -39,7 +39,7 @@ For a specific user:
 -->
 ```http
 GET /users/{user-id}@{tenant-id}/settings/windows/{windowsSettingId}
-````
+```
 
 > [!NOTE]
 > The `{tenant-id}` value must match the tenant ID of the calling user. To find your tenant ID, see [How to find your Microsoft Entra tenant ID](/entra/fundamentals/how-to-find-tenant).

--- a/api-reference/beta/api/windowssetting-list-instances.md
+++ b/api-reference/beta/api/windowssetting-list-instances.md
@@ -39,7 +39,7 @@ For a specific user:
 -->
 ```http
 GET /users/{user-id}@{tenant-id}/settings/windows/{windowsSettingId}/instances
-````
+```
 
 > [!NOTE]
 > The `{tenant-id}` value must match the tenant ID of the calling user. To find your tenant ID, see [How to find your Microsoft Entra tenant ID](/entra/fundamentals/how-to-find-tenant).

--- a/api-reference/beta/api/windowssettinginstance-get.md
+++ b/api-reference/beta/api/windowssettinginstance-get.md
@@ -39,7 +39,7 @@ For a specific user:
 -->
 ```http
 GET /users/{user-id}@{tenant-id}/settings/windows/{windowsSettingId}/instances/{windowsSettingInstanceId}
-````
+```
 
 > [!NOTE]
 > The `{tenant-id}` value must match the tenant ID of the calling user. To find your tenant ID, see [How to find your Microsoft Entra tenant ID](/entra/fundamentals/how-to-find-tenant).


### PR DESCRIPTION
Fixed missing or malformed closing code fences in 8 beta API reference topics. Issues included unclosed ```http blocks (causing Markdown to bleed into surrounding content), a quadruple-backtick closing fence (```` instead of ```), and a duplicated introductory sentence followed by a stray opening code fence. Affected topics: accesspackageresource-list-uploadsessions, security-labelsroot-delete-citations, singlevaluelegacyextendedproperty-get, usersettings-list-windows, webapplicationfirewallprovider-verify, windowssetting-get, windowssetting-list-instances, and windowssettinginstance-get.