### PR TITLE
Fix missing closing codeblock 1.0

### DIFF
--- a/api-reference/v1.0/api/security-auditlogquery-list-records.md
+++ b/api-reference/v1.0/api/security-auditlogquery-list-records.md
@@ -68,6 +68,7 @@ The following example shows a request.
 
 ```http
 GET /security/auditLog/queries
+```
 
 ---
 

--- a/api-reference/v1.0/api/userprotectionscopecontainer-compute.md
+++ b/api-reference/v1.0/api/userprotectionscopecontainer-compute.md
@@ -160,8 +160,6 @@ Content-type: application/json
 
 The following example shows the response. It indicates that uploadText, downloadText, uploadFile, or downloadFile activities for 'subdomain.domain1.com', 'domain2.com' or 'https://subdomain.domain3.com/content/subcontent' require offline evaluation. UploadText activity for 'subdomain.domain1.com', 'domain2.com' or 'https://subdomain.domain3.com/content/subcontent' require inline evaluation.
 
-```http
-
 > **Note:** The response object shown here might be shortened for readability.
 
 ```http

--- a/api-reference/v1.0/api/usersettings-list-windows.md
+++ b/api-reference/v1.0/api/usersettings-list-windows.md
@@ -31,7 +31,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 -->
 ```http
 GET /me/settings/windows
-````
+```
 
 ## Optional query parameters
 


### PR DESCRIPTION
Fixed missing or malformed closing code fences in 3 v1.0 API reference topics. Issues varied by file: security-auditlogquery-list-records.md had a missing closing ``` after an HTTP request example; userprotectionscopecontainer-compute.md had a stray opening  ```http  fence inserted before the Note callout and the actual response code block, causing the Note to render inside a code block; and usersettings-list-windows.md used a quadruple-backtick closing fence (````) instead of the correct triple-backtick.