### PR TITLE
Fix trailing pipe tables 1.0

### DIFF
--- a/api-reference/v1.0/api/b2xidentityuserflow-post-userattributeassignments.md
+++ b/api-reference/v1.0/api/b2xidentityuserflow-post-userattributeassignments.md
@@ -56,7 +56,7 @@ The following table lists the properties that are required when you create the [
 |requiresVerification|Boolean|Determines whether the identityUserFlowAttribute requires verification. This is only used for verifying the user's phone number or email address.|
 |userAttributeValues|[userAttributeValuesItem](../resources/userattributevaluesitem.md) collection|The input options for the user flow attribute. Only applicable when the userInputType is `radioSingleSelect`, `dropdownSingleSelect`, or `checkboxMultiSelect`.|
 |userInputType|identityUserFlowAttributeInputType|The input type of the user flow attribute. The possible values are: `textBox`, `dateTimeDropdown`, `radioSingleSelect`, `dropdownSingleSelect`, `emailBox`, `checkboxMultiSelect`.|
-|userAttribute|[identityUserFlowAttribute](../resources/identityuserflowattribute.md)|The identifier for the user flow attribute to include in the user flow assignment.
+|userAttribute|[identityUserFlowAttribute](../resources/identityuserflowattribute.md)|The identifier for the user flow attribute to include in the user flow assignment.|
 
 ## Response
 

--- a/api-reference/v1.0/api/basesitepage-delete.md
+++ b/api-reference/v1.0/api/basesitepage-delete.md
@@ -38,10 +38,10 @@ DELETE /sites/{site-id}/pages/{page-id}
 
 ## Request headers
 
-| Name       | Value | Description
-|:-----------|:------|:--------------------------------------------------------
+| Name       | Value | Description|
+|:-----------|:------|:--------------------------------------------------------|
 |Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).| Required|
-| _if-match_ | etag  | If this request header is included and the eTag provided doesn't match the current tag on the item, a `412 Precondition Failed` response is returned and the item won't be deleted.
+| _if-match_ | etag  | If this request header is included and the eTag provided doesn't match the current tag on the item, a `412 Precondition Failed` response is returned and the item won't be deleted.|
 
 ## Request body
 

--- a/api-reference/v1.0/api/bundle-update.md
+++ b/api-reference/v1.0/api/bundle-update.md
@@ -42,7 +42,7 @@ PATCH /drive/items/{bundle-id}
 | Name          | Description  |
 |:------------- |:------------ |
 |Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
-| if-match      | eTag. Optional. If this request header is included and the eTag provided does not match the current eTag on the buncle, a `412 Precondition Failed` response is returned.|
+| if-match      | eTag. Optional. If this request header is included and the eTag provided does not match the current eTag on the bundle, a `412 Precondition Failed` response is returned.|
 
 ## Request body
 

--- a/api-reference/v1.0/api/bundle-update.md
+++ b/api-reference/v1.0/api/bundle-update.md
@@ -42,7 +42,7 @@ PATCH /drive/items/{bundle-id}
 | Name          | Description  |
 |:------------- |:------------ |
 |Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
-| if-match      | eTag. Optional. If this request header is included and the eTag provided does not match the current eTag on the buncle, a `412 Precondition Failed` response is returned.
+| if-match      | eTag. Optional. If this request header is included and the eTag provided does not match the current eTag on the buncle, a `412 Precondition Failed` response is returned.|
 
 ## Request body
 

--- a/api-reference/v1.0/api/call-redirect.md
+++ b/api-reference/v1.0/api/call-redirect.md
@@ -45,7 +45,7 @@ In the request body, provide a JSON object with the following parameters.
 
 | Parameter      | Type    |Description|
 |:---------------|:--------|:----------|
-|targets|[invitationParticipantInfo](../resources/invitationparticipantinfo.md) collection|The target participants of the redirect operation. If more than one target is specified, it's a simulring call. This means that all of the targets are rang at the same time and only the first target that picks up will be connected. We support up to 25 targets for simulring.
+|targets|[invitationParticipantInfo](../resources/invitationparticipantinfo.md) collection|The target participants of the redirect operation. If more than one target is specified, it's a simulring call. This means that all of the targets are rang at the same time and only the first target that picks up will be connected. We support up to 25 targets for simulring.|
 |timeout|Int32|The timeout (in seconds) for the redirect operation. The range of the timeout value is between 15 and 90 seconds inclusive. The default timeout value is 55 seconds for one target and 60 seconds for multiple targets (subject to change). |
 |callbackUri|String|This allows bots to provide a specific callback URI for the current call to receive later notifications. If this property hasn't been set, the bot's global callback URI is used instead. This must be `https`.|
 

--- a/api-reference/v1.0/api/call-redirect.md
+++ b/api-reference/v1.0/api/call-redirect.md
@@ -45,7 +45,7 @@ In the request body, provide a JSON object with the following parameters.
 
 | Parameter      | Type    |Description|
 |:---------------|:--------|:----------|
-|targets|[invitationParticipantInfo](../resources/invitationparticipantinfo.md) collection|The target participants of the redirect operation. If more than one target is specified, it's a simulring call. This means that all of the targets are rang at the same time and only the first target that picks up will be connected. We support up to 25 targets for simulring.|
+|targets|[invitationParticipantInfo](../resources/invitationparticipantinfo.md) collection|The target participants of the redirect operation. If more than one target is specified, it's a simulring call. This means that all of the targets are rung at the same time and only the first target that picks up will be connected. We support up to 25 targets for simulring.|
 |timeout|Int32|The timeout (in seconds) for the redirect operation. The range of the timeout value is between 15 and 90 seconds inclusive. The default timeout value is 55 seconds for one target and 60 seconds for multiple targets (subject to change). |
 |callbackUri|String|This allows bots to provide a specific callback URI for the current call to receive later notifications. If this property hasn't been set, the bot's global callback URI is used instead. This must be `https`.|
 

--- a/api-reference/v1.0/api/cloudclipboardroot-list-items.md
+++ b/api-reference/v1.0/api/cloudclipboardroot-list-items.md
@@ -51,7 +51,7 @@ This method supports `$skipToken` [OData query parameters](/graph/query-paramete
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
-|Prefer |odata.maxpagesize={x}. Optional. Specifies a preferred integer {x} page size for paginated results. Acceptable values are 1 to 200, inclusive. If not specified in the header, the default page size is 110. 
+|Prefer |odata.maxpagesize={x}. Optional. Specifies a preferred integer {x} page size for paginated results. Acceptable values are 1 to 200, inclusive. If not specified in the header, the default page size is 110.|
 
 ## Request body
 

--- a/api-reference/v1.0/api/contact-update.md
+++ b/api-reference/v1.0/api/contact-update.md
@@ -75,7 +75,7 @@ When you update structured properties such as **homeAddress**, you must pass the
 |imAddresses|String|The contact's instant messaging (IM) addresses.|
 |initials|String|The contact's initials.|
 |jobTitle|String|The contact’s job title.|
-|manager|String|The name of the contact's manager.
+|manager|String|The name of the contact's manager.|
 |middleName|String|The contact's middle name.|
 |mobilePhone|String|The contact's mobile phone number.|
 |nickName|String|The contact's nickname.|

--- a/api-reference/v1.0/api/driveitem-createlink.md
+++ b/api-reference/v1.0/api/driveitem-createlink.md
@@ -56,7 +56,7 @@ The request should be a JSON object with the following properties.
 |   Name       |  Type  |                                 Description                                  |
 | :------------| :----- | :--------------------------------------------------------------------------- |
 | **type**     | string | The type of sharing link to create. Either `view`, `edit`, or `embed`.       |
-| **password** | string | The password of the sharing link set by the creator. Optional and OneDrive Personal only.
+| **password** | string | The password of the sharing link set by the creator. Optional and OneDrive Personal only.|
 | **expirationDateTime** | string | A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission. |
 | **retainInheritedPermissions** |  Boolean          | Optional. If `true` (default), any existing inherited permissions are retained on the shared item when sharing this item for the first time. If `false`, all existing permissions are removed when sharing for the first time.  |
 | **scope** | string | Optional. The scope of link to create. Either `anonymous`, `organization`, or `users`. |
@@ -76,11 +76,11 @@ The following values are allowed for the **type** parameter.
 The following values are allowed for the **scope** parameter.
 If the **scope** parameter isn't specified, the default link type for the organization is created.
 
-| Value          | Description
-|:---------------|:------------------------------------------------------------
-| `anonymous`    | Anyone with the link has access, without needing to sign in. It may include people outside of your organization. Anonymous link support may be disabled by an administrator.
-| `organization` | Anyone signed into your organization (tenant) can use the link to get access. Only available in OneDrive for Business and SharePoint.
-| `users`        | Share only with people you choose inside or outside the organization.
+| Value          | Description|
+|:---------------|:------------------------------------------------------------|
+| `anonymous`    | Anyone with the link has access, without needing to sign in. It may include people outside of your organization. Anonymous link support may be disabled by an administrator.|
+| `organization` | Anyone signed into your organization (tenant) can use the link to get access. Only available in OneDrive for Business and SharePoint.|
+| `users`        | Share only with people you choose inside or outside the organization.|
 
 
 ## Response

--- a/api-reference/v1.0/api/driveitem-delta.md
+++ b/api-reference/v1.0/api/driveitem-delta.md
@@ -48,7 +48,7 @@ GET /users/{userId | userPrincipalName}/drive/root/delta
 
 | Parameter   | Type  | Description                                                                                                                          |
 |:-------|:-------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| token  | string | Optional. If unspecified, enumerates the hierarchy's current state. If `latest`, returns empty response with latest delta token. If a previous delta token, returns new state since that token.
+| token  | string | Optional. If unspecified, enumerates the hierarchy's current state. If `latest`, returns empty response with latest delta token. If a previous delta token, returns new state since that token.|
 
 ## Optional query parameters
 

--- a/api-reference/v1.0/api/driveitem-get-content-format.md
+++ b/api-reference/v1.0/api/driveitem-get-content-format.md
@@ -48,11 +48,11 @@ GET /drive/root:/{path and filename}:/content?format={format}
 
 The following values are valid for the **format** parameter:
 
-| Format value | Description                        | Supported source extensions
-|:-------------|:-----------------------------------|----------------------------
-| jpg          | Converts the item into JPG format. | 3g2, 3gp, 3gp2, 3gpp, 3mf, ai, arw, asf, avi, bas, bash, bat, bmp, c, cbl, cmd, cool, cpp, cr2, crw, cs, css, csv, cur, dcm, dcm30, dic, dicm, dicom, dng, doc, docx, dwg, eml, epi, eps, epsf, epsi, epub, erf, fbx, fppx, gif, glb, h, hcp, heic, heif, htm, html, ico, icon, java, jfif, jpeg, jpg, js, json, key, log, m2ts, m4a, m4v, markdown, md, mef, mov, movie, mp3, mp4, mp4v, mrw, msg, mts, nef, nrw, numbers, obj, odp, odt, ogg, orf, pages, pano, pdf, pef, php, pict, pl, ply, png, pot, potm, potx, pps, ppsx, ppsxm, ppt, pptm, pptx, ps, ps1, psb, psd, py, raw, rb, rtf, rw1, rw2, sh, sketch, sql, sr2, stl, tif, tiff, ts, txt, vb, webm, wma, wmv, xaml, xbm, xcf, xd, xml, xpm, yaml, yml
-| pdf          | Converts the item into PDF format. | doc, docx, dot, dotx, dotm, dsn, dwg, eml, epub, fluidframework, form, htm, html, loop, loot, markdown, md, msg, note, odp, ods, odt, page, pps, ppsx, ppt, pptx, pulse, rtf, task, tif, tiff, wbtx, whiteboard, xls, xlsm, xlsx
-| html         | Converts the item into HTML format.| loop, fluid, wbtx, whiteboard
+| Format value | Description                        | Supported source extensions|
+|:-------------|:-----------------------------------|----------------------------|
+| jpg          | Converts the item into JPG format. | 3g2, 3gp, 3gp2, 3gpp, 3mf, ai, arw, asf, avi, bas, bash, bat, bmp, c, cbl, cmd, cool, cpp, cr2, crw, cs, css, csv, cur, dcm, dcm30, dic, dicm, dicom, dng, doc, docx, dwg, eml, epi, eps, epsf, epsi, epub, erf, fbx, fppx, gif, glb, h, hcp, heic, heif, htm, html, ico, icon, java, jfif, jpeg, jpg, js, json, key, log, m2ts, m4a, m4v, markdown, md, mef, mov, movie, mp3, mp4, mp4v, mrw, msg, mts, nef, nrw, numbers, obj, odp, odt, ogg, orf, pages, pano, pdf, pef, php, pict, pl, ply, png, pot, potm, potx, pps, ppsx, ppsxm, ppt, pptm, pptx, ps, ps1, psb, psd, py, raw, rb, rtf, rw1, rw2, sh, sketch, sql, sr2, stl, tif, tiff, ts, txt, vb, webm, wma, wmv, xaml, xbm, xcf, xd, xml, xpm, yaml, yml|
+| pdf          | Converts the item into PDF format. | doc, docx, dot, dotx, dotm, dsn, dwg, eml, epub, fluidframework, form, htm, html, loop, loot, markdown, md, msg, note, odp, ods, odt, page, pps, ppsx, ppt, pptx, pulse, rtf, task, tif, tiff, wbtx, whiteboard, xls, xlsm, xlsx|
+| html         | Converts the item into HTML format.| loop, fluid, wbtx, whiteboard|
 
 ## Request headers
 

--- a/api-reference/v1.0/api/driveitem-invite.md
+++ b/api-reference/v1.0/api/driveitem-invite.md
@@ -93,7 +93,7 @@ When inviting multiple recipients, it's possible for the notification to succeed
 The following table shows some other errors that your app might encounter within the nested **innererror** objects when sending notification fails. Apps aren't required to handle these errors.
 
 | Code                           | Description                                                                          |
-|:-------------------------------|:--------------------------------------------------------------------------------------
+|:-------------------------------|:--------------------------------------------------------------------------------------|
 | accountVerificationRequired    | Account verification is required to unblock sending notifications. |
 | hipCheckRequired               | Need to solve HIP (Host Intrusion Prevention) check to unblock sending notifications. |
 | exchangeInvalidUser            | Current user's mailbox wasn't found. |

--- a/api-reference/v1.0/api/driveitem-preview.md
+++ b/api-reference/v1.0/api/driveitem-preview.md
@@ -60,10 +60,10 @@ POST /shares/{shareId}/driveItem/preview
 The body of the request defines properties of the embeddable URL your application is requesting.
 The request should be a JSON object with the following properties.
 
-|   Name      |  Type         | Description
-|:------------|:--------------|:-----------------------------------------------
-| page        | string/number | Optional. Page number of document to start at, if applicable. Specified as string for future use cases around file types such as ZIP.
-| zoom        | number        | Optional. Zoom level to start at, if applicable.
+|   Name      |  Type         | Description|
+|:------------|:--------------|:-----------------------------------------------|
+| page        | string/number | Optional. Page number of document to start at, if applicable. Specified as string for future use cases around file types such as ZIP.|
+| zoom        | number        | Optional. Zoom level to start at, if applicable.|
 
 ## Response
 
@@ -77,11 +77,11 @@ The request should be a JSON object with the following properties.
 
 The response will be a JSON object containing the following properties:
 
-| Name           | Type   | Description
-|:---------------|:-------|:---------------------------------------------------
-| getUrl         | string | URL suitable for embedding using HTTP GET (iframes, etc.)
-| postUrl        | string | URL suitable for embedding using HTTP POST (form post, JS, etc.)
-| postParameters | string | POST parameters to include if using postUrl
+| Name           | Type   | Description|
+|:---------------|:-------|:---------------------------------------------------|
+| getUrl         | string | URL suitable for embedding using HTTP GET (iframes, etc.)|
+| postUrl        | string | URL suitable for embedding using HTTP POST (form post, JS, etc.)|
+| postParameters | string | POST parameters to include if using postUrl|
 
 Either getUrl, postUrl, or both might be returned depending on the current state of embed support for the specified options.
 

--- a/api-reference/v1.0/api/itemactivitystat-getactivitybyinterval.md
+++ b/api-reference/v1.0/api/itemactivitystat-getactivitybyinterval.md
@@ -38,11 +38,11 @@ GET /sites/{site-id}/lists/{list-id}/items/{item-id}/getActivitiesByInterval(sta
 
 ## Function parameters
 
-| Parameter      | Type               | Description
-|:---------------|:-------------------|:---------------------------------------
-| startDateTime  | string (timestamp) | The start time over which to aggregate activities.
-| endDateTime    | string (timestamp) | The end time over which to aggregate activities.
-| interval       | string             | The aggregation interval.
+| Parameter      | Type               | Description|
+|:---------------|:-------------------|:---------------------------------------|
+| startDateTime  | string (timestamp) | The start time over which to aggregate activities.|
+| endDateTime    | string (timestamp) | The end time over which to aggregate activities.|
+| interval       | string             | The aggregation interval.|
 
 >**Note:** This API only supports a time range of 90 days for daily counts. The value of the `startDateTime` and `endDateTime` parameters must represent a time range of less than 90 days.
 

--- a/api-reference/v1.0/api/listitem-delete.md
+++ b/api-reference/v1.0/api/listitem-delete.md
@@ -37,7 +37,7 @@ DELETE /sites/{site-id}/lists/{list-id}/items/{item-id}
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
-| _if-match_ | ``etag`If this request header is included and the eTag provided does not match the current tag on the item, a `412 Precondition Failed` response is returned and the item will not be deleted.
+| _if-match_ | ``etag`If this request header is included and the eTag provided does not match the current tag on the item, a `412 Precondition Failed` response is returned and the item will not be deleted.|
 
 ## Request body
 

--- a/api-reference/v1.0/api/listitem-update.md
+++ b/api-reference/v1.0/api/listitem-update.md
@@ -42,7 +42,7 @@ PATCH /sites/{site-id}/lists/{list-id}/items/{item-id}/fields
 |:---|:---|
 |Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
 |Content-Type|application/json. Required.|
-| _if-match_ | `etag`. If this request header is included and the eTag provided does not match the current eTag on the item, a `412 Precondition Failed` response is returned and the item will not be updated.
+| _if-match_ | `etag`. If this request header is included and the eTag provided does not match the current eTag on the item, a `412 Precondition Failed` response is returned and the item will not be updated.|
 
 ## Request body
 In the request body, supply a JSON representation of a [fieldValueSet][] specifying the fields to update.

--- a/api-reference/v1.0/api/permission-grant.md
+++ b/api-reference/v1.0/api/permission-grant.md
@@ -74,10 +74,10 @@ In the request body, provide a JSON object with the following parameters.
 }
 ```
 
-| Parameter          | Type                           | Description
-|:-------------------|:-------------------------------|:-------------------------
-| recipients         | [driveRecipient][] collection | A collection of recipients who receive access.
-| roles              | String collection             | If the link is an "existing access" link, specifies roles to be granted to the users. Otherwise must match the role of the link.
+| Parameter          | Type                           | Description|
+|:-------------------|:-------------------------------|:-------------------------|
+| recipients         | [driveRecipient][] collection | A collection of recipients who receive access.|
+| roles              | String collection             | If the link is an "existing access" link, specifies roles to be granted to the users. Otherwise must match the role of the link.|
 
 For a list of available roles, see [roles property values](../resources/permission.md#roles-property-values).
 

--- a/api-reference/v1.0/api/security-host-list-passivedns.md
+++ b/api-reference/v1.0/api/security-host-list-passivedns.md
@@ -56,7 +56,7 @@ This method supports the `$count`, `$select`, `$filter`, `$orderBy`, `$top`, and
 
 The following properties can be used for `$filter` calls:
 
-| Property    | Example                                   
+| Property    | Example|
 | :---------- | :----------------------------------------- |
 | recordType       | `$filter=recordType eq 'A'`          |
 
@@ -65,7 +65,7 @@ The following properties can be used for `$filter` calls:
 
 The following properties can be used for `$orderby` calls.
 
-| Property             | Example                              
+| Property             | Example|
 | :------------------- | :-----------------------------------  |
 | firstSeenDateTime   | `$orderby=firstSeenDateTime desc`   |
 | lastSeenDateTime | `$orderby=lastSeenDateTime desc` |   

--- a/api-reference/v1.0/api/site-list.md
+++ b/api-reference/v1.0/api/site-list.md
@@ -16,9 +16,9 @@ List all available [sites][] in an organization.
 
 Specific filter criteria and query options are also supported and described below:
 
-| Filter statement             | Select statement        | Description
-|:-----------------------------|:------------------------|:--------------------
-|`siteCollection/root ne null` | `siteCollection,webUrl` | Lists all root-level site collections in the organization. Useful for discovering the home site for each geography.
+| Filter statement             | Select statement        | Description|
+|:-----------------------------|:------------------------|:--------------------|
+|`siteCollection/root ne null` | `siteCollection,webUrl` | Lists all root-level site collections in the organization. Useful for discovering the home site for each geography.|
 
 In addition, you can use a **[$search][]** query against the `/sites` collection to find sites matching given keywords.
 If you want to list all sites across all geographies, refer to [getAllSites][].

--- a/api-reference/v1.0/api/tablecolumncollection-add.md
+++ b/api-reference/v1.0/api/tablecolumncollection-add.md
@@ -44,7 +44,8 @@ In the request body, provide a JSON object with the following parameters.
 |:---------------|:--------|:----------|
 |index|Int32|Specifies the relative position of the new column. The previous column at this position is shifted to the right. The index value should be equal to or less than the last column's index value, so it can't be used to append a column at the end of the table. Zero-indexed.|
 |values|Json|Optional. A two-dimensional array of unformatted values of the table column.|
-|name|string|name
+|name|string|name|
+
 ## Response
 
 If successful, this method returns `200 OK` response code and [workbookTableColumn](../resources/workbooktablecolumn.md) object in the response body.

--- a/api-reference/v1.0/api/user-findmeetingtimes.md
+++ b/api-reference/v1.0/api/user-findmeetingtimes.md
@@ -62,7 +62,7 @@ The following table describes the **activityDomain** restrictions you can furthe
 |work| Suggestions are within the user's work hours which are defined in the user’s calendar configuration and can be customized by the user or administrator. The default work hours are Monday to Friday, 8am to 5pm in the time zone set for the mailbox. This is the default value if no **activityDomain** is specified. |
 |personal| Suggestions are within the user's work hours, and Saturday and Sunday. The default is Monday to Sunday, 8am to 5pm, in the time zone setting for the mailbox.|
 |unrestricted | Suggestions can be from all hours of a day, all days of a week.|
-|unknown | Do not use this value as it will be deprecated in the future. Currently behaves the same as `work`. Change any existing code to use `work`, `personal` or `unrestricted` as appropriate.
+|unknown | Do not use this value as it will be deprecated in the future. Currently behaves the same as `work`. Change any existing code to use `work`, `personal` or `unrestricted` as appropriate.|
 
 
 Based on the specified parameters,**findMeetingTimes** checks the free/busy status in the primary calendars of the organizer and attendees. The action


### PR DESCRIPTION
Fixed missing trailing pipe characters on table rows across 19 v1.0 API reference topics in the Microsoft Graph documentation. Markdown tables require a closing | on every row to render correctly; without it, the table either breaks or renders as plain text. The fix adds the missing trailing pipes to affected rows in property tables, parameter tables, request header tables, and response tables. Topics span identity (B2X user flows), Files and SharePoint (drive items, list items, site pages, content types, site list), communications (calls), cloud clipboard, security, and calendar (find meeting times, table column collection). This PR is the v1.0 counterpart to PR #9929, which addressed the same issue in the beta API reference.
