### PR TITLE
Unhide callerIdNumber on voiceAuthenticationMethodConfiguration (beta)

### DIFF
--- a/api-reference/beta/api/voiceauthenticationmethodconfiguration-get.md
+++ b/api-reference/beta/api/voiceauthenticationmethodconfiguration-get.md
@@ -6,7 +6,7 @@ ms.reviewer: intelligentaccesspm
 ms.localizationpriority: medium
 ms.subservice: "entra-sign-in"
 doc_type: apiPageType
-ms.date: 04/05/2024
+ms.date: 06/15/2026
 ---
 
 # Get voiceAuthenticationMethodConfiguration
@@ -119,7 +119,8 @@ Content-Type: application/json
       }
     ],
     "excludeTargets": [],
-    "isOfficePhoneAllowed": "true"
+    "isOfficePhoneAllowed": "true",
+    "callerIdNumber": null
   }
 }
 ```

--- a/api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md
@@ -6,7 +6,7 @@ ms.reviewer: intelligentaccesspm
 ms.localizationpriority: medium
 ms.subservice: "entra-sign-in"
 doc_type: apiPageType
-ms.date: 04/05/2024
+ms.date: 06/15/2026
 ---
 
 # Update voiceAuthenticationMethodConfiguration
@@ -47,6 +47,7 @@ PATCH /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/v
 
 |Property|Type|Description|
 |:---|:---|:---|
+|callerIdNumber|String|The caller ID number to be used when voice call authentication method phone calls are placed. Only US phone numbers are supported.|
 |excludeTargets|[excludeTarget](../resources/excludetarget.md) collection|Groups of users that are excluded from the policy.|
 |isOfficePhoneAllowed|Boolean|`true` if users can register office phones, otherwise, `false`.|
 |state|authenticationMethodState|The possible values are: `enabled`, `disabled`.|

--- a/api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md
@@ -47,7 +47,7 @@ PATCH /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/v
 
 |Property|Type|Description|
 |:---|:---|:---|
-|callerIdNumber|String|The caller ID number to be used when voice call authentication method phone calls are placed. Only US phone numbers are supported.|
+|callerIdNumber|String|The caller ID number to be used when voice call authentication method phone calls are placed. Only US phone numbers are supported. The value must be specified in [E.164](https://en.wikipedia.org/wiki/E.164) format, for example, `+15551234567`.|
 |excludeTargets|[excludeTarget](../resources/excludetarget.md) collection|Groups of users that are excluded from the policy.|
 |isOfficePhoneAllowed|Boolean|`true` if users can register office phones, otherwise, `false`.|
 |state|authenticationMethodState|The possible values are: `enabled`, `disabled`.|

--- a/api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md
@@ -47,7 +47,7 @@ PATCH /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/v
 
 |Property|Type|Description|
 |:---|:---|:---|
-|callerIdNumber|String|The caller ID number to be used when voice call authentication method phone calls are placed. Only US phone numbers are supported. The value must be specified in [E.164](https://en.wikipedia.org/wiki/E.164) format, for example, `+15551234567`.|
+|callerIdNumber|String|The caller ID phone number to display when voice call authentication method calls are placed.|
 |excludeTargets|[excludeTarget](../resources/excludetarget.md) collection|Groups of users that are excluded from the policy.|
 |isOfficePhoneAllowed|Boolean|`true` if users can register office phones, otherwise, `false`.|
 |state|authenticationMethodState|The possible values are: `enabled`, `disabled`.|

--- a/api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md
@@ -47,7 +47,7 @@ PATCH /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/v
 
 |Property|Type|Description|
 |:---|:---|:---|
-|callerIdNumber|String|The caller ID phone number to display when voice call authentication method calls are placed.|
+|callerIdNumber|String|The caller ID phone number to display when voice call authentication method calls are placed. Only US phone numbers are supported. The value should be a 10-digit US number (for example, `2065551234`) or an 11-digit number with the US country code prefix `1` (for example, `12065551234`). Non-numeric characters are ignored. If the value isn't a valid US phone number, the system default caller ID is used.|
 |excludeTargets|[excludeTarget](../resources/excludetarget.md) collection|Groups of users that are excluded from the policy.|
 |isOfficePhoneAllowed|Boolean|`true` if users can register office phones, otherwise, `false`.|
 |state|authenticationMethodState|The possible values are: `enabled`, `disabled`.|

--- a/api-reference/beta/resources/voiceauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/voiceauthenticationmethodconfiguration.md
@@ -30,7 +30,7 @@ Inherits from [authenticationMethodConfiguration](../resources/authenticationmet
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|callerIdNumber|String|The caller ID number to be used when voice call authentication method phone calls are placed. Only US phone numbers are supported. The value must be specified in [E.164](https://en.wikipedia.org/wiki/E.164) format, for example, `+15551234567`.|
+|callerIdNumber|String|The caller ID phone number to display when voice call authentication method calls are placed.|
 |excludeTargets|[excludeTarget](../resources/excludetarget.md) collection|Groups of users that are excluded from the policy.|
 |id|String|The authentication method policy identifier.|
 |isOfficePhoneAllowed|Boolean|`true` if users can register office phones, otherwise, `false`. |
@@ -56,7 +56,7 @@ The following is a JSON representation of the resource.
   "@odata.type": "#microsoft.graph.voiceAuthenticationMethodConfiguration",
   "id": "String (identifier)",
   "state": "String",
-  "callerIdNumber": "+15551234567",
+  "callerIdNumber": "String",
   "excludeTargets": [
     {
       "@odata.type": "microsoft.graph.excludeTarget"

--- a/api-reference/beta/resources/voiceauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/voiceauthenticationmethodconfiguration.md
@@ -7,7 +7,7 @@ ms.localizationpriority: medium
 ms.subservice: "entra-sign-in"
 doc_type: resourcePageType
 toc.title: Voice
-ms.date: 07/22/2024
+ms.date: 06/15/2026
 ---
 
 # voiceAuthenticationMethodConfiguration resource type
@@ -30,6 +30,7 @@ Inherits from [authenticationMethodConfiguration](../resources/authenticationmet
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
+|callerIdNumber|String|The caller ID number to be used when voice call authentication method phone calls are placed. Only US phone numbers are supported.|
 |excludeTargets|[excludeTarget](../resources/excludetarget.md) collection|Groups of users that are excluded from the policy.|
 |id|String|The authentication method policy identifier.|
 |isOfficePhoneAllowed|Boolean|`true` if users can register office phones, otherwise, `false`. |
@@ -55,6 +56,7 @@ The following is a JSON representation of the resource.
   "@odata.type": "#microsoft.graph.voiceAuthenticationMethodConfiguration",
   "id": "String (identifier)",
   "state": "String",
+  "callerIdNumber": "String",
   "excludeTargets": [
     {
       "@odata.type": "microsoft.graph.excludeTarget"

--- a/api-reference/beta/resources/voiceauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/voiceauthenticationmethodconfiguration.md
@@ -30,7 +30,7 @@ Inherits from [authenticationMethodConfiguration](../resources/authenticationmet
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|callerIdNumber|String|The caller ID phone number to display when voice call authentication method calls are placed.|
+|callerIdNumber|String|The caller ID phone number to display when voice call authentication method calls are placed. Only US phone numbers are supported. The value should be a 10-digit US number (for example, `2065551234`) or an 11-digit number with the US country code prefix `1` (for example, `12065551234`). Non-numeric characters are ignored. If the value isn't a valid US phone number, the system default caller ID is used.|
 |excludeTargets|[excludeTarget](../resources/excludetarget.md) collection|Groups of users that are excluded from the policy.|
 |id|String|The authentication method policy identifier.|
 |isOfficePhoneAllowed|Boolean|`true` if users can register office phones, otherwise, `false`. |

--- a/api-reference/beta/resources/voiceauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/voiceauthenticationmethodconfiguration.md
@@ -30,7 +30,7 @@ Inherits from [authenticationMethodConfiguration](../resources/authenticationmet
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|callerIdNumber|String|The caller ID number to be used when voice call authentication method phone calls are placed. Only US phone numbers are supported.|
+|callerIdNumber|String|The caller ID number to be used when voice call authentication method phone calls are placed. Only US phone numbers are supported. The value must be specified in [E.164](https://en.wikipedia.org/wiki/E.164) format, for example, `+15551234567`.|
 |excludeTargets|[excludeTarget](../resources/excludetarget.md) collection|Groups of users that are excluded from the policy.|
 |id|String|The authentication method policy identifier.|
 |isOfficePhoneAllowed|Boolean|`true` if users can register office phones, otherwise, `false`. |
@@ -56,7 +56,7 @@ The following is a JSON representation of the resource.
   "@odata.type": "#microsoft.graph.voiceAuthenticationMethodConfiguration",
   "id": "String (identifier)",
   "state": "String",
-  "callerIdNumber": "String",
+  "callerIdNumber": "+15551234567",
   "excludeTargets": [
     {
       "@odata.type": "microsoft.graph.excludeTarget"


### PR DESCRIPTION
## Summary

Unhides the `callerIdNumber` property on `voiceAuthenticationMethodConfiguration` in the beta API documentation. This property was previously hidden behind a private preview annotation in the AGS schema and is now being exposed publicly.

## What changed

Added the `callerIdNumber` property (type: `String`) to:

1. **Resource type doc** (`api-reference/beta/resources/voiceauthenticationmethodconfiguration.md`):
   - Added to Properties table with description
   - Added to JSON representation

2. **GET API doc** (`api-reference/beta/api/voiceauthenticationmethodconfiguration-get.md`):
   - Added `callerIdNumber` to the response example

3. **UPDATE API doc** (`api-reference/beta/api/voiceauthenticationmethodconfiguration-update.md`):
   - Added `callerIdNumber` to the request body properties table

## Related changes

- **AGS schema change**: [PR #15464627](https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/15464627) — Unhides `callerIdNumber` on `voiceAuthenticationMethodConfiguration` in `schema-Prod-beta.csdl` by removing `ags:IsHidden` and the deprecated annotation.