### PR TITLE
[Docs] Remove license-type availability banner from Graph beta eDiscovery overview

### DIFF
--- a/api-reference/beta/resources/ediscovery-ediscoveryapioverview.md
+++ b/api-reference/beta/resources/ediscovery-ediscoveryapioverview.md
@@ -18,9 +18,7 @@ The Microsoft Graph APIs for eDiscovery enable organizations to automate repetit
 > The Microsoft Graph APIs for eDiscovery are intended for the use of eDiscovery operations for litigation, investigation, and regulatory requests. These APIs shouldn't be used as a substitute for journaling data out of the Microsoft 365 system or any other mass download.
 
 > [!NOTE]
-> During the preview, usage of these APIs may require subscriptions to specific Microsoft offerings and is subject to the [Microsoft APIs Terms of Use](/legal/microsoft-apis/terms-of-use?context=graph%252fcontext).  Upon general availability, Microsoft may require you or your customer to pay additional fees.
->
-> Currently, the eDiscovery APIs in Microsoft Graph only work with Advanced eDiscovery cases.
+> Entitlement and feature availability for the eDiscovery APIs in Microsoft Graph are determined by Microsoft Purview eDiscovery configuration and service-side enablement. For current licensing and capability guidance, see the [Microsoft Purview eDiscovery documentation](/purview/edisc).
 
 The eDiscovery API is defined in the OData subnamespace, microsoft.graph.ediscovery. The API includes the following key entities.
 


### PR DESCRIPTION
## Summary

Removes license-type availability banner language from the Graph beta eDiscovery API overview page. Replaces preview/SKU-specific note with neutral guidance pointing to Microsoft Purview eDiscovery documentation.

## Why

Customer confusion (tracked in `IcM 51000001064141`) reported via the eDiscovery OnCall channel: customers attempting to create a search in a **standard** eDiscovery case via Microsoft Graph were blocked or confused by the existing banner asserting that "the eDiscovery APIs in Microsoft Graph only work with Advanced eDiscovery cases" and the related preview-licensing note.

That wording is stale — entitlement and feature availability are managed by Microsoft Purview eDiscovery service-side, and the API reference shouldn't embed license/SKU assertions that drift from product behavior.

## What changed

**File:** `api-reference/beta/resources/ediscovery-ediscoveryapioverview.md`

**Before:**
```
> [!NOTE]
> During the preview, usage of these APIs may require subscriptions to specific Microsoft offerings and is subject to the [Microsoft APIs Terms of Use](/legal/microsoft-apis/terms-of-use?context=graph%2Fcontext).  Upon general availability, Microsoft may require you or your customer to pay additional fees.
>
> Currently, the eDiscovery APIs in Microsoft Graph only work with Advanced eDiscovery cases.
```

**After:**
```
> [!NOTE]
> Entitlement and feature availability for the eDiscovery APIs in Microsoft Graph are determined by Microsoft Purview eDiscovery configuration and service-side enablement. For current licensing and capability guidance, see the [Microsoft Purview eDiscovery documentation](/purview/edisc).
```

## Impact

- Removes inaccurate "Advanced eDiscovery only" wording from API reference.
- Removes preview-era licensing note that no longer reflects current product behavior.
- Points readers to the authoritative Purview eDiscovery doc set for licensing/entitlement.
- No API surface change.

## References

- IcM `51000001064141` — `[OED] | [Issue] Unable to create a search in a standard eDiscovery case using MS graph`
