### PR TITLE
[Places][v1.0] Promote placeId and servicePlans docs (ADO 16323411)

### DIFF
--- a/api-reference/v1.0/resources/desk.md
+++ b/api-reference/v1.0/resources/desk.md
@@ -34,6 +34,7 @@ For the list of supported methods, see [place](./place.md).
 |mode |[placeMode](./placemode.md) |The mode of the desk. The supported modes are:<ul><li>[assignedPlaceMode](./assignedplacemode.md) - Desks that are assigned to a user.</li><li>[reservablePlaceMode](./reservableplacemode.md) - Desks that can be booked in advance using desk reservation tools.</li><li>[dropInPlaceMode](./dropinplacemode.md) - First come, first served desks. When you plug into a peripheral on one of these desks, the desk is booked for you, assuming the peripheral is associated with the desk in the Microsoft Teams Rooms pro management portal.</li><li>[unavailablePlaceMode](./unavailableplacemode.md) - Desks that are taken down for maintenance or marked as not reservable.</li></ul> |
 |parentId|String|The ID of a parent [section](./section.md). Inherited from [place](./place.md).|
 |phone|String|The phone number of the **desk**. Inherited from [place](./place.md).|
+|servicePlans|[placeServicePlanInfo](./placeserviceplaninfo.md) collection|The service plans associated with the **desk**.|
 |tags|String collection|Custom tags that are associated with the **desk** for categorization or filtering. Inherited from [place](./place.md).|
 
 ## Relationships
@@ -64,6 +65,7 @@ The following JSON representation shows the resource type.
   "mode": {"@odata.type": "microsoft.graph.placeMode"},
   "parentId": "String",
   "phone": "String",
+  "servicePlans": [{"@odata.type": "microsoft.graph.placeServicePlanInfo"}],
   "tags": ["String"]
 }
 ```

--- a/api-reference/v1.0/resources/place.md
+++ b/api-reference/v1.0/resources/place.md
@@ -40,6 +40,7 @@ Inherits from [entity](../resources/entity.md).
 |id |String |The unique identifier for the **place**. Read-only. This identifier isn't immutable and can change if the mailbox or tenant configuration changes. |
 |isWheelChairAccessible |Boolean |Indicates whether the **place** is wheelchair accessible. |
 |parentId |String |The ID of a parent **place**. |
+|placeId |String |A stable service-level identifier for the **place** object used by Places workloads. |
 |phone |String |The phone number of the **place**. |
 |tags |String collection |Custom tags that are associated with the **place** for categorization or filtering. |
 
@@ -68,6 +69,7 @@ The following JSON representation shows the resource type.
   "isWheelChairAccessible": "Boolean",
   "label": "String",
   "parentId": "String",
+  "placeId": "String",
   "phone": "String",
   "tags": ["String"]
 }


### PR DESCRIPTION
## Summary\nPromote the approved Places beta contract changes to v1.0 docs.\n\n## Changes\n- Add placeId to v1.0 place resource properties and JSON representation.\n- Add servicePlans to v1.0 desk resource properties and JSON representation.\n\n## Source API Review\n- ADO work item / PR context: https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/16323411\n\n## Files\n- pi-reference/v1.0/resources/place.md\n- pi-reference/v1.0/resources/desk.md\n