### PR TITLE
Add SAP AC connection info resource docs (IGAELM beta)

### DIFF
--- a/api-reference/beta/resources/authenticationinfo.md
+++ b/api-reference/beta/resources/authenticationinfo.md
@@ -1,0 +1,41 @@
+---
+title: "authenticationInfo resource type"
+description: "An abstract base type that represents the authentication configuration used to connect to an external system."
+author: "vikama-microsoft"
+ms.date: 07/13/2026
+ms.localizationpriority: medium
+ms.subservice: "entra-id-governance"
+doc_type: resourcePageType
+---
+
+# authenticationInfo resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+An abstract base type that represents the authentication configuration used by Microsoft Entra Entitlement Management to connect to an external system. This is an abstract type and can't be created directly. Use one of its derived types instead.
+
+The following types are derived from authenticationInfo:
+
+- [clientCredentialAuthenticationInfo](../resources/clientcredentialauthenticationinfo.md)
+
+## Properties
+None.
+
+## Relationships
+None.
+
+## JSON representation
+The following JSON representation shows the resource type.
+<!-- {
+  "blockType": "resource",
+  "abstract": true,
+  "@odata.type": "microsoft.graph.authenticationInfo"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.authenticationInfo"
+}
+```

--- a/api-reference/beta/resources/clientcredentialauthenticationinfo.md
+++ b/api-reference/beta/resources/clientcredentialauthenticationinfo.md
@@ -1,0 +1,45 @@
+---
+title: "clientCredentialAuthenticationInfo resource type"
+description: "Represents client credential authentication information used to connect to an external system from Microsoft Entra Entitlement Management."
+author: "vikama-microsoft"
+ms.date: 07/13/2026
+ms.localizationpriority: medium
+ms.subservice: "entra-id-governance"
+doc_type: resourcePageType
+---
+
+# clientCredentialAuthenticationInfo resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Represents client credential (OAuth 2.0 client credentials) authentication information used by Microsoft Entra Entitlement Management to connect to an external system, including the client identifier, the Azure Key Vault secret reference, and the token endpoint.
+
+Inherits from [authenticationInfo](../resources/authenticationinfo.md).
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|accessTokenUrl|String|The URL endpoint used to obtain access tokens for authentication with the external system.|
+|clientId|String|The client identifier used for authentication with the external system.|
+|secretName|String|The name of the secret in Azure Key Vault that contains the client secret.|
+
+## Relationships
+None.
+
+## JSON representation
+The following JSON representation shows the resource type.
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.clientCredentialAuthenticationInfo"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.clientCredentialAuthenticationInfo",
+  "clientId": "String",
+  "secretName": "String",
+  "accessTokenUrl": "String"
+}
+```

--- a/api-reference/beta/resources/connectioninfo.md
+++ b/api-reference/beta/resources/connectioninfo.md
@@ -18,6 +18,7 @@ The connectionInfo object defines the resource locator that is used to communica
 
 The following types are derived from connectionInfo:
 
+- [externalSapAcConnectionInfo](../resources/externalsapacconnectioninfo.md)
 - [externalTokenBasedSapIagConnectionInfo](../resources/externaltokenbasedsapiagconnectioninfo.md)
 
 In entitlement management, this object is configured in the following properties and relationships:

--- a/api-reference/beta/resources/externalsapacconnectioninfo.md
+++ b/api-reference/beta/resources/externalsapacconnectioninfo.md
@@ -1,0 +1,55 @@
+---
+title: "externalSapAcConnectionInfo resource type"
+description: "Represents connection information for connecting to SAP Access Control (AC) systems from Microsoft Entra Entitlement Management."
+author: "vikama-microsoft"
+ms.date: 07/13/2026
+ms.localizationpriority: medium
+ms.subservice: "entra-id-governance"
+doc_type: resourcePageType
+---
+
+# externalSapAcConnectionInfo resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Represents connection information for connecting to SAP Access Control (AC) systems from Microsoft Entra Entitlement Management. This resource contains the configuration details required to establish a secure connection between an Entitlement Management [accessPackageResource](../resources/accesspackageresource.md)'s **externalOriginResourceConnector** and an SAP AC system, including the target system identity and Azure Key Vault references for credential storage. Used when connectorType in [externalOriginResourceConnector](../resources/externaloriginresourceconnector.md) is `sapAc`.
+
+Inherits from [connectionInfo](../resources/connectioninfo.md).
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|authenticationInfo|[microsoft.graph.authenticationInfo](../resources/authenticationinfo.md)|The authentication configuration used to connect to the SAP AC system.|
+|keyVaultName|String|The name of the Azure Key Vault that stores the credentials used for authentication.|
+|resourceGroup|String|The Azure resource group that contains the Key Vault.|
+|subscriptionId|String|The Azure subscription ID that contains the Key Vault.|
+|systemId|String|The identifier of the target SAP AC system.|
+|url|String|The endpoint that is used by Entitlement Management to communicate with the SAP AC system. Inherited from [connectionInfo](../resources/connectioninfo.md).|
+|userIdentifier|String|The user identifier used to connect to the SAP AC system.|
+
+## Relationships
+None.
+
+## JSON representation
+The following JSON representation shows the resource type.
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.externalSapAcConnectionInfo"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.externalSapAcConnectionInfo",
+  "url": "String",
+  "subscriptionId": "String",
+  "resourceGroup": "String",
+  "keyVaultName": "String",
+  "systemId": "String",
+  "userIdentifier": "String",
+  "authenticationInfo": {
+    "@odata.type": "microsoft.graph.authenticationInfo"
+  }
+}
+```

--- a/changelog/Microsoft.IGAELM.json
+++ b/changelog/Microsoft.IGAELM.json
@@ -3,6 +3,40 @@
     {
       "ChangeList": [
         {
+          "Id": "01c542b5-f4e5-48ec-9fe8-8b63fdb7ad42",
+          "ApiChange": "Resource",
+          "ChangedApiName": "externalSapAcConnectionInfo",
+          "ChangeType": "Addition",
+          "Description": "Added the [externalSapAcConnectionInfo](https://learn.microsoft.com/en-us/graph/api/resources/externalsapacconnectioninfo?view=graph-rest-beta) complex type.",
+          "Target": "externalSapAcConnectionInfo"
+        },
+        {
+          "Id": "01c542b5-f4e5-48ec-9fe8-8b63fdb7ad42",
+          "ApiChange": "Resource",
+          "ChangedApiName": "clientCredentialAuthenticationInfo",
+          "ChangeType": "Addition",
+          "Description": "Added the [clientCredentialAuthenticationInfo](https://learn.microsoft.com/en-us/graph/api/resources/clientcredentialauthenticationinfo?view=graph-rest-beta) complex type.",
+          "Target": "clientCredentialAuthenticationInfo"
+        },
+        {
+          "Id": "01c542b5-f4e5-48ec-9fe8-8b63fdb7ad42",
+          "ApiChange": "Resource",
+          "ChangedApiName": "authenticationInfo",
+          "ChangeType": "Addition",
+          "Description": "Added the [authenticationInfo](https://learn.microsoft.com/en-us/graph/api/resources/authenticationinfo?view=graph-rest-beta) abstract complex type.",
+          "Target": "authenticationInfo"
+        }
+      ],
+      "Id": "01c542b5-f4e5-48ec-9fe8-8b63fdb7ad42",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-13T00:00:00Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Governance"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "bbaab297-9f65-4f97-8abb-a67a10d5a6e1",
           "ApiChange": "Method",
           "ChangedApiName": "Get",


### PR DESCRIPTION
> [!IMPORTANT]
> Required for API changes:
> - [x] Link to API.md file: [API review PR 12942265](https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/12942265)
> - [x] Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl): [AD-AggregatorService-Workloads PR 15556430](https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/15556430)

---
Add other supporting information, such as a description of the PR changes:

Documents new complex types added to the `Microsoft.IGAELM` beta schema (`schema-Prod-beta.csdl`) in schema PR 15556430. These support connecting Microsoft Entra Entitlement Management to SAP Access Control (AC) systems.

New resource type docs (`api-reference/beta/resources/`):
- **externalSapAcConnectionInfo** — inherits `connectionInfo`; connection details for SAP AC systems (`subscriptionId`, `resourceGroup`, `keyVaultName`, `systemId`, `userIdentifier`, `authenticationInfo`).
- **clientCredentialAuthenticationInfo** — inherits `authenticationInfo`; client credential authentication details (`clientId`, `secretName`, `accessTokenUrl`).
- **authenticationInfo** — abstract base type for authentication configuration.

Other changes:
- Updated `connectioninfo.md` to list `externalSapAcConnectionInfo` as a derived type.
- Added a changelog entry in `changelog/Microsoft.IGAELM.json` (beta, Prod) for the three new complex types.
