### PR TITLE
[Intune] Sprint 2607 PE Beta - Graph API changelog update

### DIFF
--- a/changelog/Microsoft.Intune.json
+++ b/changelog/Microsoft.Intune.json
@@ -3,6 +3,348 @@
     {
       "ChangeList": [
         {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Enumeration",
+          "ChangedApiName": "mobileAppContentFileUploadErrorCode",
+          "ChangeType": "Addition",
+          "Description": "Added the **mobileAppContentFileUploadErrorCode** enumeration type.",
+          "Target": "mobileAppContentFileUploadErrorCode"
+        },
+        {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Member",
+          "ChangedApiName": "dependencyAppInUse",
+          "ChangeType": "Addition",
+          "Description": "Added the `dependencyAppInUse` member to the **resultantAppStateDetail** enumeration.",
+          "Target": "resultantAppStateDetail"
+        },
+        {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Member",
+          "ChangedApiName": "inUse",
+          "ChangeType": "Addition",
+          "Description": "Added the `inUse` member to the **resultantAppStateDetail** enumeration.",
+          "Target": "resultantAppStateDetail"
+        },
+        {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Member",
+          "ChangedApiName": "deferred",
+          "ChangeType": "Addition",
+          "Description": "Added the `deferred` member to the **resultantAppStateDetail** enumeration.",
+          "Target": "resultantAppStateDetail"
+        },
+        {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Member",
+          "ChangedApiName": "autoDeferred",
+          "ChangeType": "Addition",
+          "Description": "Added the `autoDeferred` member to the **resultantAppStateDetail** enumeration.",
+          "Target": "resultantAppStateDetail"
+        },
+        {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Property",
+          "ChangedApiName": "ddmAppConfigId",
+          "ChangeType": "Addition",
+          "Description": "Added the **ddmAppConfigId** property to the [iosDdmLobAppAssignmentSettings](https://learn.microsoft.com/en-us/graph/api/resources/intune-iosDdmLobAppAssignmentSettings?view=graph-rest-beta) resource.",
+          "Target": "iosDdmLobAppAssignmentSettings"
+        },
+        {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Property",
+          "ChangedApiName": "ddmAppConfigId",
+          "ChangeType": "Addition",
+          "Description": "Added the **ddmAppConfigId** property to the [iosDdmVppAppAssignmentSettings](https://learn.microsoft.com/en-us/graph/api/resources/intune-iosDdmVppAppAssignmentSettings?view=graph-rest-beta) resource.",
+          "Target": "iosDdmVppAppAssignmentSettings"
+        },
+        {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Property",
+          "ChangedApiName": "ddmAppConfigId",
+          "ChangeType": "Addition",
+          "Description": "Added the **ddmAppConfigId** property to the [macOsDdmVppAppAssignmentSettings](https://learn.microsoft.com/en-us/graph/api/resources/intune-macOsDdmVppAppAssignmentSettings?view=graph-rest-beta) resource.",
+          "Target": "macOsDdmVppAppAssignmentSettings"
+        },
+        {
+          "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+          "ApiChange": "Property",
+          "ChangedApiName": "uploadErrorCode",
+          "ChangeType": "Addition",
+          "Description": "Added the **uploadErrorCode** property to the [mobileAppContentFile](https://learn.microsoft.com/en-us/graph/api/resources/intune-mobileAppContentFile?view=graph-rest-beta) resource.",
+          "Target": "mobileAppContentFile"
+        }
+      ],
+      "Id": "c500126d-fef6-44c5-b421-1470001acf0b",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-23T00:36:53.2459801Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Corporate management"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "1e695087-2a43-471e-b2d7-082f178c0bfb",
+          "ApiChange": "Resource",
+          "ChangedApiName": "deviceConfigurationUserStateSummary",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [deviceConfigurationUserStateSummary](https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceConfigurationUserStateSummary?view=graph-rest-beta) resource.",
+          "Target": "deviceConfigurationUserStateSummary"
+        },
+        {
+          "Id": "1e695087-2a43-471e-b2d7-082f178c0bfb",
+          "ApiChange": "Resource",
+          "ChangedApiName": "deviceManagement",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [deviceManagement](https://learn.microsoft.com/en-us/graph/api/resources/intune-deviceManagement?view=graph-rest-beta) resource.",
+          "Target": "deviceManagement"
+        },
+        {
+          "Id": "1e695087-2a43-471e-b2d7-082f178c0bfb",
+          "ApiChange": "Annotation",
+          "ChangedApiName": "Org.OData.Core.V1.Revisions",
+          "ChangeType": "Deprecation",
+          "Description": "Removed the **Org.OData.Core.V1.Revisions** resource.",
+          "Target": "refreshDeviceComplianceReportSummarization"
+        }
+      ],
+      "Id": "1e695087-2a43-471e-b2d7-082f178c0bfb",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-23T00:36:53.2459926Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Corporate management"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "e533e9df-63c0-4587-92f5-3fccf81ba1bf",
+          "ApiChange": "Member",
+          "ChangedApiName": "intuneOpenExtensibility",
+          "ChangeType": "Addition",
+          "Description": "Added the `intuneOpenExtensibility` member to the **deviceManagementConfigurationTechnologies** enumeration.",
+          "Target": "deviceManagementConfigurationTechnologies"
+        }
+      ],
+      "Id": "e533e9df-63c0-4587-92f5-3fccf81ba1bf",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-23T00:36:53.2459969Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Corporate management"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "managedDevice",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [managedDevice](https://learn.microsoft.com/en-us/graph/api/resources/intune-managedDevice?view=graph-rest-beta) resource.",
+          "Target": "managedDevice"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineCategoryStateSummary",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineCategoryStateSummary](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineCategoryStateSummary?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineCategoryStateSummary"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineDeviceState",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineDeviceState](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineDeviceState?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineDeviceState"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineSettingState",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineSettingState](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineSettingState?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineSettingState"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineState",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineState](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineState?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineState"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineState",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineState](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineState?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineState"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineStateSummary",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineStateSummary](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineStateSummary?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineStateSummary"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineTemplate",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineTemplate](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineTemplate?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineTemplate"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineTemplate",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineTemplate](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineTemplate?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineTemplate"
+        },
+        {
+          "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+          "ApiChange": "Resource",
+          "ChangedApiName": "securityBaselineTemplate",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated the [securityBaselineTemplate](https://learn.microsoft.com/en-us/graph/api/resources/intune-securityBaselineTemplate?view=graph-rest-beta) resource.",
+          "Target": "securityBaselineTemplate"
+        }
+      ],
+      "Id": "d20492a3-3f08-4d3b-954f-f110135ce76e",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-23T00:36:53.2460003Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Corporate management"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "3cf40537-5e22-47c7-bfa2-84bf2ce57739",
+          "ApiChange": "Enumeration",
+          "ChangedApiName": "eSimProfileErrorDetail",
+          "ChangeType": "Addition",
+          "Description": "Added the **eSimProfileErrorDetail** enumeration type.",
+          "Target": "eSimProfileErrorDetail"
+        },
+        {
+          "Id": "3cf40537-5e22-47c7-bfa2-84bf2ce57739",
+          "ApiChange": "Enumeration",
+          "ChangedApiName": "eSimProfileState",
+          "ChangeType": "Addition",
+          "Description": "Added the **eSimProfileState** enumeration type.",
+          "Target": "eSimProfileState"
+        }
+      ],
+      "Id": "3cf40537-5e22-47c7-bfa2-84bf2ce57739",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-23T00:36:53.246007Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Corporate management"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "241dc851-1e79-4aac-a001-d16894e02ea8",
+          "ApiChange": "Member",
+          "ChangedApiName": "intuneOpenExtensibility",
+          "ChangeType": "Addition",
+          "Description": "Added the `intuneOpenExtensibility` member to the **deviceManagementConfigurationTechnologies** enumeration.",
+          "Target": "deviceManagementConfigurationTechnologies"
+        },
+        {
+          "Id": "241dc851-1e79-4aac-a001-d16894e02ea8",
+          "ApiChange": "Member",
+          "ChangedApiName": "selectedApps",
+          "ChangeType": "Addition",
+          "Description": "Added the `selectedApps` member to the **windowsManagedAppDataTransferLevel** enumeration.",
+          "Target": "windowsManagedAppDataTransferLevel"
+        },
+        {
+          "Id": "241dc851-1e79-4aac-a001-d16894e02ea8",
+          "ApiChange": "Enumeration",
+          "ChangedApiName": "windowsManagedAppDataTransferLocations",
+          "ChangeType": "Addition",
+          "Description": "Added the **windowsManagedAppDataTransferLocations** enumeration type.",
+          "Target": "windowsManagedAppDataTransferLocations"
+        },
+        {
+          "Id": "241dc851-1e79-4aac-a001-d16894e02ea8",
+          "ApiChange": "Property",
+          "ChangedApiName": "appActionIfDeveloperOptionsEnabled",
+          "ChangeType": "Addition",
+          "Description": "Added the **appActionIfDeveloperOptionsEnabled** property to the [androidManagedAppProtection](https://learn.microsoft.com/en-us/graph/api/resources/intune-androidManagedAppProtection?view=graph-rest-beta) resource.",
+          "Target": "androidManagedAppProtection"
+        },
+        {
+          "Id": "241dc851-1e79-4aac-a001-d16894e02ea8",
+          "ApiChange": "Property",
+          "ChangedApiName": "allowedInboundDataTransferSourceApps",
+          "ChangeType": "Addition",
+          "Description": "Added the **allowedInboundDataTransferSourceApps** property to the [windowsManagedAppProtection](https://learn.microsoft.com/en-us/graph/api/resources/intune-windowsManagedAppProtection?view=graph-rest-beta) resource.",
+          "Target": "windowsManagedAppProtection"
+        },
+        {
+          "Id": "241dc851-1e79-4aac-a001-d16894e02ea8",
+          "ApiChange": "Property",
+          "ChangedApiName": "allowedOutboundDataTransferDestinationApps",
+          "ChangeType": "Addition",
+          "Description": "Added the **allowedOutboundDataTransferDestinationApps** property to the [windowsManagedAppProtection](https://learn.microsoft.com/en-us/graph/api/resources/intune-windowsManagedAppProtection?view=graph-rest-beta) resource.",
+          "Target": "windowsManagedAppProtection"
+        }
+      ],
+      "Id": "241dc851-1e79-4aac-a001-d16894e02ea8",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-23T00:36:53.2460164Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Corporate management"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "a0ac5dbc-7331-41b6-bfb3-7ba02b6ef5ef",
+          "ApiChange": "Enumeration",
+          "ChangedApiName": "remoteHelpRecordingState",
+          "ChangeType": "Addition",
+          "Description": "Added the **remoteHelpRecordingState** enumeration type.",
+          "Target": "remoteHelpRecordingState"
+        },
+        {
+          "Id": "a0ac5dbc-7331-41b6-bfb3-7ba02b6ef5ef",
+          "ApiChange": "Property",
+          "ChangedApiName": "remoteHelpRecordingState",
+          "ChangeType": "Addition",
+          "Description": "Added the **remoteHelpRecordingState** property to the [createRemoteHelpSessionResponse](https://learn.microsoft.com/en-us/graph/api/resources/intune-createRemoteHelpSessionResponse?view=graph-rest-beta) resource.",
+          "Target": "createRemoteHelpSessionResponse"
+        },
+        {
+          "Id": "a0ac5dbc-7331-41b6-bfb3-7ba02b6ef5ef",
+          "ApiChange": "Parameter",
+          "ChangedApiName": "partnerDomain",
+          "ChangeType": "Addition",
+          "Description": "Added the `partnerDomain` parameter to the [beginOnboarding](https://learn.microsoft.com/en-us/graph/api/intune-remoteAssistancePartner?view=graph-rest-beta) method.",
+          "Target": "beginOnboarding"
+        }
+      ],
+      "Id": "a0ac5dbc-7331-41b6-bfb3-7ba02b6ef5ef",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-23T00:36:53.2460231Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Corporate management"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "1ef2d0c3-3ec9-407b-acd4-1ee9791691ce",
           "ApiChange": "Resource",
           "ChangedApiName": "samsungEFotaFirmwareVersion",


### PR DESCRIPTION
## Summary

Adds changelog entries for the Intune Sprint 2607 Production (Beta) release.

## Changes

| Workload | Changes |
|----------|---------|
| Applications | 9 (new enum type, enum members, properties) |
| DeviceConfiguration | 3 (IsHidden on WiFi security enum members) |
| DeviceConfigV2 | 1 (new enum member) |
| DeviceIntent | 10 (new types, properties, relationships) |
| Devices | 2 (new properties) |
| ManagedApplications | 6 (new enum members, properties) |
| RemoteAssistance | 3 (new action parameters) |

## Related

- PE Beta CSDL PR: https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/16495889