### PR TITLE
Add appliedByUser parameter to assignSensitivityLabel API

### DIFF
--- a/api-reference/beta/api/driveitem-assignsensitivitylabel.md
+++ b/api-reference/beta/api/driveitem-assignsensitivitylabel.md
@@ -88,7 +88,9 @@ The following table lists the possible values for the error types.
 
 ## Examples
 
-### Request
+### Example 1: Assign a sensitivity label
+
+#### Request
 
 The following example shows a request.
 
@@ -112,7 +114,7 @@ Content-Type: application/json
 
 ---
 
-### Response
+#### Response
 
 The following example shows the response.
 
@@ -148,6 +150,7 @@ Content-Type: application/json
 
 Alternatively, identify the user by their user principal name.
 
+<!-- { "blockType": "request", "name": "assignSensitivityLabel_apponly_upn", "tags": "service.graph", "sampleKeys": ["016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U"] } -->
 ``` http
 POST https://graph.microsoft.com/beta/drives/{drive-id}/items/016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U/assignSensitivityLabel
 Content-Type: application/json
@@ -167,6 +170,7 @@ Content-Type: application/json
 <!-- { "blockType": "response" } -->
 ```http
 HTTP/1.1 202 Accepted
+Location: https://contoso.sharepoint.com/_api/v2.0/monitor/QXNzaWduU2Vuc2l0aXZpdHlMYWJlbCxiMzc3ODY3OS04OWQ3LTRkYmYtYjg0MC1jYWM1NzRhY2FlNmE?tempAuth=******
 ```
 
 ### Remarks

--- a/api-reference/beta/api/driveitem-assignsensitivitylabel.md
+++ b/api-reference/beta/api/driveitem-assignsensitivitylabel.md
@@ -67,6 +67,7 @@ In the request body, provide the ID for the sensitivity label that is to be assi
 | sensitivityLabelId  | String  | Required. ID of the sensitivity label to be assigned, or empty string to remove the sensitivity label.              |
 | assignmentMethod    | [sensitivityLabelAssignmentMethod](/graph/api/resources/sensitivitylabelassignment?view=graph-rest-beta&preserve-view=true#sensitivitylabelassignmentmethod-values) | Optional. The assignment method of the label on the document. Indicates whether the assignment of the label was done automatically, standard, or as a privileged operation (the equivalent of an administrator operation).     |
 | justificationText   | String | Optional. Justification text for audit purposes. Required when downgrading or removing a label.  |
+| appliedByUser       | [userIdentity](/graph/api/resources/useridentity?view=graph-rest-beta&preserve-view=true) | Optional. The identity of the user on whose behalf the label is applied. Supported only in application (app-only) context. Specify either `id` (Entra Object ID) or `userPrincipalName`. |
 
 ## Response
 
@@ -123,6 +124,50 @@ Location: https://contoso.sharepoint.com/_api/v2.0/monitor/QXNzaWduU2Vuc2l0aXZpd
 
 The value of the `Location` header provides a URL for a service that will return the current state of the assignSensitivityLabel operation.
 You can use this information to [determine when the assignSensitivityLabel operation has finished](/graph/long-running-actions-overview).
+
+### Example 2: Assign a sensitivity label on behalf of a user (app-only)
+
+#### Request
+
+The following example shows an app-only request that assigns a label on behalf of a specific user, identified by Entra Object ID.
+
+<!-- { "blockType": "request", "name": "assignSensitivityLabel_apponly_id", "tags": "service.graph", "sampleKeys": ["016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U"] } -->
+``` http
+POST https://graph.microsoft.com/beta/drives/{drive-id}/items/016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U/assignSensitivityLabel
+Content-Type: application/json
+
+{
+  "sensitivityLabelId": "5feba255-812e-446a-ac59-a7044ef827b5",
+  "assignmentMethod": "standard",
+  "justificationText": "test_justification",
+  "appliedByUser": {
+    "id": "4a2ec3c4-1b2d-3e4f-5a6b-7c8d9e0f1a2b"
+  }
+}
+```
+
+Alternatively, identify the user by their user principal name.
+
+``` http
+POST https://graph.microsoft.com/beta/drives/{drive-id}/items/016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U/assignSensitivityLabel
+Content-Type: application/json
+
+{
+  "sensitivityLabelId": "5feba255-812e-446a-ac59-a7044ef827b5",
+  "assignmentMethod": "standard",
+  "justificationText": "test_justification",
+  "appliedByUser": {
+    "userPrincipalName": "adelev@contoso.com"
+  }
+}
+```
+
+#### Response
+
+<!-- { "blockType": "response" } -->
+```http
+HTTP/1.1 202 Accepted
+```
 
 ### Remarks
 

--- a/api-reference/beta/api/driveitem-assignsensitivitylabel.md
+++ b/api-reference/beta/api/driveitem-assignsensitivitylabel.md
@@ -148,7 +148,19 @@ Content-Type: application/json
 }
 ```
 
-Alternatively, identify the user by their user principal name.
+#### Response
+
+<!-- { "blockType": "response" } -->
+```http
+HTTP/1.1 202 Accepted
+Location: https://contoso.sharepoint.com/_api/v2.0/monitor/QXNzaWduU2Vuc2l0aXZpdHlMYWJlbCxiMzc3ODY3OS04OWQ3LTRkYmYtYjg0MC1jYWM1NzRhY2FlNmE?tempAuth=******
+```
+
+### Example 3: Assign a sensitivity label on behalf of a user using UPN (app-only)
+
+#### Request
+
+The following example shows an app-only request that identifies the user by their user principal name.
 
 <!-- { "blockType": "request", "name": "assignSensitivityLabel_apponly_upn", "tags": "service.graph", "sampleKeys": ["016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U"] } -->
 ``` http

--- a/api-reference/v1.0/api/driveitem-assignsensitivitylabel.md
+++ b/api-reference/v1.0/api/driveitem-assignsensitivitylabel.md
@@ -146,7 +146,19 @@ Content-Type: application/json
 }
 ```
 
-Alternatively, identify the user by their user principal name.
+#### Response
+
+<!-- { "blockType": "response" } -->
+```http
+HTTP/1.1 202 Accepted
+Location: https://contoso.sharepoint.com/_api/v2.0/monitor/QXNzaWduU2Vuc2l0aXZpdHlMYWJlbCxiMzc3ODY3OS04OWQ3LTRkYmYtYjg0MC1jYWM1NzRhY2FlNmE?tempAuth=******
+```
+
+### Example 3: Assign a sensitivity label on behalf of a user using UPN (app-only)
+
+#### Request
+
+The following example shows an app-only request that identifies the user by their user principal name.
 
 <!-- { "blockType": "request", "name": "assignSensitivityLabel_apponly_upn", "tags": "service.graph", "sampleKeys": ["016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U"] } -->
 ``` http

--- a/api-reference/v1.0/api/driveitem-assignsensitivitylabel.md
+++ b/api-reference/v1.0/api/driveitem-assignsensitivitylabel.md
@@ -86,7 +86,9 @@ The following table lists the possible values for the error types.
 
 ## Examples
 
-### Request
+### Example 1: Assign a sensitivity label
+
+#### Request
 
 The following example shows a request.
 
@@ -110,7 +112,7 @@ Content-Type: application/json
 
 ---
 
-### Response
+#### Response
 
 The following example shows the response.
 
@@ -146,6 +148,7 @@ Content-Type: application/json
 
 Alternatively, identify the user by their user principal name.
 
+<!-- { "blockType": "request", "name": "assignSensitivityLabel_apponly_upn", "tags": "service.graph", "sampleKeys": ["016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U"] } -->
 ``` http
 POST https://graph.microsoft.com/v1.0/drives/{drive-id}/items/016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U/assignSensitivityLabel
 Content-Type: application/json
@@ -165,6 +168,7 @@ Content-Type: application/json
 <!-- { "blockType": "response" } -->
 ```http
 HTTP/1.1 202 Accepted
+Location: https://contoso.sharepoint.com/_api/v2.0/monitor/QXNzaWduU2Vuc2l0aXZpdHlMYWJlbCxiMzc3ODY3OS04OWQ3LTRkYmYtYjg0MC1jYWM1NzRhY2FlNmE?tempAuth=******
 ```
 
 ### Remarks

--- a/api-reference/v1.0/api/driveitem-assignsensitivitylabel.md
+++ b/api-reference/v1.0/api/driveitem-assignsensitivitylabel.md
@@ -65,6 +65,7 @@ In the request body, provide the ID for the sensitivity label that is to be assi
 | sensitivityLabelId  | String  | Required. ID of the sensitivity label to be assigned, or empty string to remove the sensitivity label.              |
 | assignmentMethod    | [sensitivityLabelAssignmentMethod](/graph/api/resources/sensitivitylabelassignment?view=graph-rest-1.0&preserve-view=true#sensitivitylabelassignmentmethod-values) | Optional. The assignment method of the label on the document. Indicates whether the assignment of the label was done automatically, standard, or as a privileged operation (the equivalent of an administrator operation).     |
 | justificationText   | String | Optional. Justification text for audit purposes, and is required when downgrading/removing a label.  |
+| appliedByUser       | [userIdentity](/graph/api/resources/useridentity?view=graph-rest-1.0&preserve-view=true) | Optional. The identity of the user on whose behalf the label is applied. Supported only in application (app-only) context. Specify either `id` (Entra Object ID) or `userPrincipalName`. |
 
 ## Response
 
@@ -121,6 +122,50 @@ Location: https://contoso.sharepoint.com/_api/v2.0/monitor/QXNzaWduU2Vuc2l0aXZpd
 
 The value of the `Location` header provides a URL for a service that returns the current state of the assignSensitivityLabel operation.
 You can use this information to [determine when the assignSensitivityLabel operation finishes](/graph/long-running-actions-overview).
+
+### Example 2: Assign a sensitivity label on behalf of a user (app-only)
+
+#### Request
+
+The following example shows an app-only request that assigns a label on behalf of a specific user, identified by Entra Object ID.
+
+<!-- { "blockType": "request", "name": "assignSensitivityLabel_apponly_id", "tags": "service.graph", "sampleKeys": ["016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U"] } -->
+``` http
+POST https://graph.microsoft.com/v1.0/drives/{drive-id}/items/016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U/assignSensitivityLabel
+Content-Type: application/json
+
+{
+  "sensitivityLabelId": "5feba255-812e-446a-ac59-a7044ef827b5",
+  "assignmentMethod": "standard",
+  "justificationText": "test_justification",
+  "appliedByUser": {
+    "id": "4a2ec3c4-1b2d-3e4f-5a6b-7c8d9e0f1a2b"
+  }
+}
+```
+
+Alternatively, identify the user by their user principal name.
+
+``` http
+POST https://graph.microsoft.com/v1.0/drives/{drive-id}/items/016GVDAP3RCQS5VBQHORFIVU2ZMOSBL25U/assignSensitivityLabel
+Content-Type: application/json
+
+{
+  "sensitivityLabelId": "5feba255-812e-446a-ac59-a7044ef827b5",
+  "assignmentMethod": "standard",
+  "justificationText": "test_justification",
+  "appliedByUser": {
+    "userPrincipalName": "adelev@contoso.com"
+  }
+}
+```
+
+#### Response
+
+<!-- { "blockType": "response" } -->
+```http
+HTTP/1.1 202 Accepted
+```
 
 ### Remarks
 

--- a/changelog/Microsoft.SharePoint.json
+++ b/changelog/Microsoft.SharePoint.json
@@ -33,7 +33,7 @@
           "ChangeType": "Addition",
           "Description": "Added the [sharePointReportSettings](https://learn.microsoft.com/en-us/graph/api/resources/sharepointreportsettings?view=graph-rest-beta) resource and an associated method.",
           "Target": "sharePointReportSettings"
-        },
+          },
         {
           "Id": "47429c7d-024e-4b43-ac1a-43f466fcbe10",
           "ApiChange": "Method",
@@ -49,7 +49,7 @@
           "ChangeType": "Addition",
           "Description": "Added the [enableApiUsageReport](https://learn.microsoft.com/en-us/graph/api/sharepointreportsettings-enableapiusagereport?view=graph-rest-beta) method to the [sharePointReportSettings](https://learn.microsoft.com/en-us/graph/api/resources/sharepointreportsettings?view=graph-rest-beta) resource.",
           "Target": "sharePointReportSettings"
-        }
+          }
       ],
       "Id": "47429c7d-024e-4b43-ac1a-43f466fcbe10",
       "Cloud": "Prod",
@@ -465,40 +465,40 @@
       "SubArea": ""
     },
     {
-      "Id": "87e904df-d6a6-4e69-a697-bdfa505f9d2d",
-      "Version": "beta",
-      "WorkloadArea": "Sites and lists",
-      "SubArea": "",
-      "CreatedDateTime": "2026-07-27T06:57:00.0000000Z",
       "ChangeList": [
         {
-          "Description": "Added the **appliedByUser** parameter to the [assignSensitivityLabel](https://learn.microsoft.com/en-us/graph/api/driveitem-assignsensitivitylabel?view=graph-rest-beta&preserve-view=true) action on [driveItem](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-beta&preserve-view=true). This parameter allows app-only callers to specify the user on whose behalf the label is applied.",
           "Id": "87e904df-d6a6-4e69-a697-bdfa505f9d2d",
           "ApiChange": "Parameter",
-          "Target": "driveItem",
+          "ChangedApiName": "appliedByUser",
           "ChangeType": "Addition",
-          "ChangedApiName": "appliedByUser"
+          "Description": "Added the **appliedByUser** parameter to the [assignSensitivityLabel](https://learn.microsoft.com/en-us/graph/api/driveitem-assignsensitivitylabel?view=graph-rest-beta&preserve-view=true) action on [driveItem](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-beta&preserve-view=true). This parameter allows app-only callers to specify the user on whose behalf the label is applied.",
+          "Target": "driveItem"
         }
       ],
-      "Cloud": "Prod"
+      "Id": "87e904df-d6a6-4e69-a697-bdfa505f9d2d",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-27T06:57:00.0000000Z",
+      "WorkloadArea": "Sites and lists",
+      "SubArea": ""
     },
     {
-      "Id": "0ed23253-c04f-42ae-8648-de8a21154a97",
-      "Version": "v1.0",
-      "WorkloadArea": "Sites and lists",
-      "SubArea": "",
-      "CreatedDateTime": "2026-07-27T06:57:00.0000000Z",
       "ChangeList": [
         {
-          "Description": "Added the **appliedByUser** parameter to the [assignSensitivityLabel](https://learn.microsoft.com/en-us/graph/api/driveitem-assignsensitivitylabel?view=graph-rest-1.0&preserve-view=true) action on [driveItem](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0&preserve-view=true). This parameter allows app-only callers to specify the user on whose behalf the label is applied.",
           "Id": "0ed23253-c04f-42ae-8648-de8a21154a97",
           "ApiChange": "Parameter",
-          "Target": "driveItem",
+          "ChangedApiName": "appliedByUser",
           "ChangeType": "Addition",
-          "ChangedApiName": "appliedByUser"
+          "Description": "Added the **appliedByUser** parameter to the [assignSensitivityLabel](https://learn.microsoft.com/en-us/graph/api/driveitem-assignsensitivitylabel?view=graph-rest-1.0&preserve-view=true) action on [driveItem](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0&preserve-view=true). This parameter allows app-only callers to specify the user on whose behalf the label is applied.",
+          "Target": "driveItem"
         }
       ],
-      "Cloud": "Prod"
+      "Id": "0ed23253-c04f-42ae-8648-de8a21154a97",
+      "Cloud": "Prod",
+      "Version": "v1.0",
+      "CreatedDateTime": "2026-07-27T06:57:00.0000000Z",
+      "WorkloadArea": "Sites and lists",
+      "SubArea": ""
     }
   ]
 }

--- a/changelog/Microsoft.SharePoint.json
+++ b/changelog/Microsoft.SharePoint.json
@@ -33,7 +33,7 @@
           "ChangeType": "Addition",
           "Description": "Added the [sharePointReportSettings](https://learn.microsoft.com/en-us/graph/api/resources/sharepointreportsettings?view=graph-rest-beta) resource and an associated method.",
           "Target": "sharePointReportSettings"
-          },
+        },
         {
           "Id": "47429c7d-024e-4b43-ac1a-43f466fcbe10",
           "ApiChange": "Method",
@@ -49,7 +49,7 @@
           "ChangeType": "Addition",
           "Description": "Added the [enableApiUsageReport](https://learn.microsoft.com/en-us/graph/api/sharepointreportsettings-enableapiusagereport?view=graph-rest-beta) method to the [sharePointReportSettings](https://learn.microsoft.com/en-us/graph/api/resources/sharepointreportsettings?view=graph-rest-beta) resource.",
           "Target": "sharePointReportSettings"
-          }
+        }
       ],
       "Id": "47429c7d-024e-4b43-ac1a-43f466fcbe10",
       "Cloud": "Prod",
@@ -463,6 +463,42 @@
       "CreatedDateTime": "2020-03-01T00:00:00",
       "WorkloadArea": "Sites and lists",
       "SubArea": ""
+    },
+    {
+      "Id": "87e904df-d6a6-4e69-a697-bdfa505f9d2d",
+      "Version": "beta",
+      "WorkloadArea": "Sites and lists",
+      "SubArea": "",
+      "CreatedDateTime": "2026-07-27T06:57:00.0000000Z",
+      "ChangeList": [
+        {
+          "Description": "Added the **appliedByUser** parameter to the [assignSensitivityLabel](https://learn.microsoft.com/en-us/graph/api/driveitem-assignsensitivitylabel?view=graph-rest-beta&preserve-view=true) action on [driveItem](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-beta&preserve-view=true). This parameter allows app-only callers to specify the user on whose behalf the label is applied.",
+          "Id": "87e904df-d6a6-4e69-a697-bdfa505f9d2d",
+          "ApiChange": "Parameter",
+          "Target": "driveItem",
+          "ChangeType": "Addition",
+          "ChangedApiName": "appliedByUser"
+        }
+      ],
+      "Cloud": "Prod"
+    },
+    {
+      "Id": "0ed23253-c04f-42ae-8648-de8a21154a97",
+      "Version": "v1.0",
+      "WorkloadArea": "Sites and lists",
+      "SubArea": "",
+      "CreatedDateTime": "2026-07-27T06:57:00.0000000Z",
+      "ChangeList": [
+        {
+          "Description": "Added the **appliedByUser** parameter to the [assignSensitivityLabel](https://learn.microsoft.com/en-us/graph/api/driveitem-assignsensitivitylabel?view=graph-rest-1.0&preserve-view=true) action on [driveItem](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0&preserve-view=true). This parameter allows app-only callers to specify the user on whose behalf the label is applied.",
+          "Id": "0ed23253-c04f-42ae-8648-de8a21154a97",
+          "ApiChange": "Parameter",
+          "Target": "driveItem",
+          "ChangeType": "Addition",
+          "ChangedApiName": "appliedByUser"
+        }
+      ],
+      "Cloud": "Prod"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Documents the new `appliedByUser` parameter for the `assignSensitivityLabel` action on `driveItem`.

This parameter allows app-only callers to specify the user identity (by Entra OID or UPN) on whose behalf the sensitivity label is applied.

## Required Links
- API.md files: Updated in this PR (beta + v1.0)
- Schema PR: https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/16520600

## Changes
- Added `appliedByUser` (type: `userIdentity`) to request body parameter table
- Added new "Example 2" showing app-only usage with OID and UPN
- Added changelog entries for both beta and v1.0