### PR TITLE
Clarify Group-NestingSupport permission for update group.md

### DIFF
--- a/api-reference/v1.0/api/group-update.md
+++ b/api-reference/v1.0/api/group-update.md
@@ -6,7 +6,7 @@ ms.reviewer: "mbhargav, khotzteam, aadgroupssg"
 ms.localizationpriority: high
 ms.subservice: "entra-groups"
 doc_type: apiPageType
-ms.date: 08/20/2024
+ms.date: 07/27/2026
 ---
 
 # Update group
@@ -33,6 +33,8 @@ Choose the permission or permissions marked as least privileged for this API. Us
 [!INCLUDE [permissions-table](../includes/permissions/group-update-permissions.md)]
 
 ### Permissions for specific scenarios
+
+- *Group-NestingSupport.ReadWrite.All* is the least privileged permission to update the **disableNesting** property.
 
 - *Group.ManageProtection.All* delegated permission is the least privileged permission to update the **assignedLabels** property for cloud security groups. App-only scenarios aren't supported.
 


### PR DESCRIPTION
This is a documentation-only clarification. It doesn't change the Microsoft Graph API or public schema.

**Changes:**
- Documents Group-NestingSupport.ReadWrite.All under Permissions for specific scenarios because it applies specifically to the disableNesting property.
- Updates the article date.

Maintainer action required:
The permissions table is generated and still lists Group-NestingSupport.ReadWrite.All as the least privileged permission for general group updates. Please update the permissions metadata and regenerate the table so Group.ReadWrite.All is listed for general updates.

API.md: N/A — no API change.
Public schema PR: N/A — no schema change.



> [!IMPORTANT]
> Use the AI-powered workflow for Graph onboarding to author and self-review schema-related changes. See https://aka.ms/msgraphcdk for more information.
> 
> Required for API changes:
> - [] Link to API.md file: N/A - documentation only change
> - [] Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl):  *N/A - documentation only changes

---
Add other supporting information, such as a description of the PR changes:

*See the documentation-change summary above*

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
