### PR TITLE
Document GSA health monitoring enum values

### DIFF
--- a/api-reference/beta/resources/enums-healthmonitoring.md
+++ b/api-reference/beta/resources/enums-healthmonitoring.md
@@ -35,6 +35,10 @@ Namespace: microsoft.graph.healthMonitoring
 |unknownFutureValue|
 |conditionalAccessBlockedSignIn|
 |samlSignInFailure|
+|internetAppBlockedByPolicy|
+|privateAppBlockedByConnector|
+|remoteNetworkTunnelConnectivity|
+|remoteNetworkBgpConnectivity|
 
 ### category values 
 
@@ -69,6 +73,7 @@ Namespace: microsoft.graph.healthMonitoring
 |unknownFutureValue|
 |conditionalAccess|
 |saml|
+|gsa|
 
 <!--
 {

--- a/api-reference/beta/resources/healthmonitoring-alert.md
+++ b/api-reference/beta/resources/healthmonitoring-alert.md
@@ -31,13 +31,13 @@ Inherits from [microsoft.graph.entity](../resources/entity.md).
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|alertType|microsoft.graph.healthMonitoring.alertType|Indicates which type of scenario an alert is associated with. The possible values are: `unknown`, `mfaSignInFailure`, `managedDeviceSignInFailure`, `compliantDeviceSignInFailure`, `unknownFutureValue`, `conditionalAccessBlockedSignIn`, `samlSignInFailure`. Use the `Prefer: include-unknown-enum-members` request header to get the following value or values in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `conditionalAccessBlockedSignIn`, `samlSignInFailure`. Supports `$filter` (`eq`).|
+|alertType|microsoft.graph.healthMonitoring.alertType|Indicates which type of scenario an alert is associated with. The possible values are: `unknown`, `mfaSignInFailure`, `managedDeviceSignInFailure`, `compliantDeviceSignInFailure`, `unknownFutureValue`, `conditionalAccessBlockedSignIn`, `samlSignInFailure`, `internetAppBlockedByPolicy`, `privateAppBlockedByConnector`, `remoteNetworkTunnelConnectivity`, `remoteNetworkBgpConnectivity`. Use the `Prefer: include-unknown-enum-members` request header to get the following value or values in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `conditionalAccessBlockedSignIn`, `samlSignInFailure`, `internetAppBlockedByPolicy`, `privateAppBlockedByConnector`, `remoteNetworkTunnelConnectivity`, `remoteNetworkBgpConnectivity`. Supports `$filter` (`eq`).|
 |category|microsoft.graph.healthMonitoring.category|The classification that groups the scenario. The possible values are: `unknown`, `authentication`, `unknownFutureValue`. |
 |createdDateTime|DateTimeOffset|The time when Microsoft Entra Health monitoring generated the alert. Supports `$orderby`.|
 |documentation|[microsoft.graph.healthMonitoring.documentation](../resources/healthmonitoring-documentation.md)|A key-value pair that contains the name of and link to the documentation to aid in investigation of the alert.|
 |enrichment|[microsoft.graph.healthMonitoring.enrichment](../resources/healthmonitoring-enrichment.md)|Investigative information on the alert. This information typically includes counts of impacted objects, which include directory objects such as users, groups, and devices, and a pointer to supporting data.|
 |id|String|The unique GUID identifier of this alert in the associated tenant. Inherited from [microsoft.graph.entity](../resources/entity.md).|
-|scenario|microsoft.graph.healthMonitoring.scenario|The area being monitored on the system that is emitting the source signals. The possible values are: `unknown`, `mfa`, `devices`, `unknownFutureValue`, `conditionalAccess`, `saml`. Use the `Prefer: include-unknown-enum-members` request header to get the following value or values in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `conditionalAccess`, `saml`.|
+|scenario|microsoft.graph.healthMonitoring.scenario|The area being monitored on the system that is emitting the source signals. The possible values are: `unknown`, `mfa`, `devices`, `unknownFutureValue`, `conditionalAccess`, `saml`, `gsa`. Use the `Prefer: include-unknown-enum-members` request header to get the following value or values in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `conditionalAccess`, `saml`, `gsa`.|
 |signals|[microsoft.graph.healthMonitoring.signals](../resources/healthmonitoring-signals.md)|The collection of signals that were used in the generation of the alert. These signals are sourced from [serviceActivity APIs](../resources/serviceactivity.md) and are added to the alert as key-value pairs.|
 |state|microsoft.graph.healthMonitoring.alertState|The current lifecycle state of the alert. The possible values are: `active`, `resolved`, `unknownFutureValue`.|
 
@@ -74,4 +74,3 @@ The following JSON representation shows the resource type.
   }
 }
 ```
-

--- a/changelog/Microsoft.AAD.Reporting.json
+++ b/changelog/Microsoft.AAD.Reporting.json
@@ -3,6 +3,56 @@
     {
       "ChangeList": [
         {
+          "Id": "1aa30cd5-36f9-4569-a810-eda9a538cfc3",
+          "ApiChange": "Member",
+          "ChangedApiName": "internetAppBlockedByPolicy",
+          "ChangeType": "Addition",
+          "Description": "Added the `internetAppBlockedByPolicy` member to the **alertType** enumeration.",
+          "Target": "alertType"
+        },
+        {
+          "Id": "1aa30cd5-36f9-4569-a810-eda9a538cfc3",
+          "ApiChange": "Member",
+          "ChangedApiName": "privateAppBlockedByConnector",
+          "ChangeType": "Addition",
+          "Description": "Added the `privateAppBlockedByConnector` member to the **alertType** enumeration.",
+          "Target": "alertType"
+        },
+        {
+          "Id": "1aa30cd5-36f9-4569-a810-eda9a538cfc3",
+          "ApiChange": "Member",
+          "ChangedApiName": "remoteNetworkTunnelConnectivity",
+          "ChangeType": "Addition",
+          "Description": "Added the `remoteNetworkTunnelConnectivity` member to the **alertType** enumeration.",
+          "Target": "alertType"
+        },
+        {
+          "Id": "1aa30cd5-36f9-4569-a810-eda9a538cfc3",
+          "ApiChange": "Member",
+          "ChangedApiName": "remoteNetworkBgpConnectivity",
+          "ChangeType": "Addition",
+          "Description": "Added the `remoteNetworkBgpConnectivity` member to the **alertType** enumeration.",
+          "Target": "alertType"
+        },
+        {
+          "Id": "1aa30cd5-36f9-4569-a810-eda9a538cfc3",
+          "ApiChange": "Member",
+          "ChangedApiName": "gsa",
+          "ChangeType": "Addition",
+          "Description": "Added the `gsa` member to the **scenario** enumeration.",
+          "Target": "scenario"
+        }
+      ],
+      "Id": "1aa30cd5-36f9-4569-a810-eda9a538cfc3",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2026-07-28T20:20:59.2844447Z",
+      "WorkloadArea": "Reports",
+      "SubArea": "Identity and access reports"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "1fa63eb3-bbbb-4cb6-bb79-69f28c34c4ce",
           "ApiChange": "Resource",
           "ChangedApiName": "identityAnalyticsRoot",

--- a/concepts/whats-new-overview.md
+++ b/concepts/whats-new-overview.md
@@ -123,6 +123,10 @@ Added the [Delete mailboxItem](/graph/api/mailboxfolder-delete-items?view=graph-
 - Updated [Manage profile source precedence in Microsoft 365](/graph/profilepriority-configure-profilepropertysetting) to clarify supported data sources for HR and work position data, explain how source precedence affects single-value versus multi-value properties, and add guidance on correctly configuring and removing tenant-level settings using the Microsoft Graph API or PowerShell.
 - Added the [People data sources in Microsoft 365](/graph/people-data-sources) concept article that describes the data sources that build the Microsoft 365 user profile, including Microsoft Entra ID, Copilot connectors, Organizational data, SharePoint, People Skills, user edits, and the API user source. The article also provides a reference table of built-in source IDs (GUIDs) and explains how source metadata appears in the profile API output.
 
+### Reports | Identity and access reports
+
+Added Global Secure Access support to Microsoft Entra Health monitoring. The [alert](/graph/api/resources/healthmonitoring-alert?view=graph-rest-beta&preserve-view=true) resource now supports the `gsa` scenario and the `internetAppBlockedByPolicy`, `privateAppBlockedByConnector`, `remoteNetworkTunnelConnectivity`, and `remoteNetworkBgpConnectivity` alert types.
+
 ### Security | Alerts and incidents
 
 - Added the **tenantId** property to the [userAccount](/graph/api/resources/security-useraccount) resource to provide the Entra home tenant ID for the compromised user account indicated in a [security alert](/graph/api/resources/security-alert) where the alert evidence is related to a [processEvidence](/graph/api/resources/security-processevidence), [userEvidence](/graph/api/resources/security-userevidence), or [mailboxEvidence](/graph/api/resources/security-mailboxevidence).


### PR DESCRIPTION
## Summary
- add Global Secure Access members to the ``alertType`` and ``scenario`` enum documentation
- update the health monitoring alert resource's inline evolvable-enum value lists
- add the ``Microsoft.AAD.Reporting`` beta changelog record and What's New announcement

## Validation
- parsed ``changelog/Microsoft.AAD.Reporting.json`` and confirmed a consistent record ID and metadata
- confirmed all new enum members appear in both the enum topic and the resource's ``Prefer: include-unknown-enum-members`` lists
- confirmed the branch differs from ``main`` by only the four intended documentation files