### PR TITLE
Add SharePoint Online app+user-only note to entitlement management resource APIs

### DIFF
--- a/api-reference/beta/api/accesspackageresourceenvironment-get.md
+++ b/api-reference/beta/api/accesspackageresourceenvironment-get.md
@@ -26,7 +26,9 @@ Choose the permission or permissions marked as least privileged for this API. Us
 [!INCLUDE [rbac-entitlement-catalog-reader](../includes/rbac-for-apis/rbac-entitlement-management-catalog-reader-apis-read.md)]
 
 > [!NOTE]
-> SharePoint Online resource environments are returned only when this API is called with delegated permissions. This scenario isn't supported with application permissions. To retrieve SharePoint site information using application permissions, use the [sites: getAllSites](../api/site-getallsites.md) API, which returns equivalent site information.
+> SharePoint Online resource environments are returned only when this API is called with delegated permissions. This scenario isn't supported with application permissions.
+>
+> A SharePoint Online resource environment corresponds to a SharePoint root site. To retrieve root site information using application permissions, use the [List sites](../api/site-list.md) API and filter on the `siteCollection/root` property: `GET /sites?$select=siteCollection,webUrl&$filter=siteCollection/root ne null`. Most organizations have a single root site; multi-geo organizations have a root site for each geo location.
 
 ## HTTP request
 

--- a/api-reference/beta/api/accesspackageresourceenvironment-get.md
+++ b/api-reference/beta/api/accesspackageresourceenvironment-get.md
@@ -26,7 +26,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 [!INCLUDE [rbac-entitlement-catalog-reader](../includes/rbac-for-apis/rbac-entitlement-management-catalog-reader-apis-read.md)]
 
 > [!NOTE]
-> SharePoint Online resource environments are returned only when this API is called with delegated (app+user) permissions. This scenario isn't supported with application-only permissions. To retrieve SharePoint site information in an app-only context, use the [sites: getAllSites](site-getallsites.md) API, which returns equivalent site information.
+> SharePoint Online resource environments are returned only when this API is called with delegated permissions. This scenario isn't supported with application permissions. To retrieve SharePoint site information using application permissions, use the [sites: getAllSites](../api/site-getallsites.md) API, which returns equivalent site information.
 
 ## HTTP request
 

--- a/api-reference/beta/api/accesspackageresourceenvironment-get.md
+++ b/api-reference/beta/api/accesspackageresourceenvironment-get.md
@@ -5,7 +5,7 @@ author: "markwahl-msft"
 ms.localizationpriority: medium
 ms.subservice: "entra-id-governance"
 doc_type: apiPageType
-ms.date: 11/05/2024
+ms.date: 07/31/2026
 ---
 
 # Get accessPackageResourceEnvironment
@@ -24,6 +24,9 @@ Choose the permission or permissions marked as least privileged for this API. Us
 [!INCLUDE [permissions-table](../includes/permissions/accesspackageresourceenvironment-get-permissions.md)]
 
 [!INCLUDE [rbac-entitlement-catalog-reader](../includes/rbac-for-apis/rbac-entitlement-management-catalog-reader-apis-read.md)]
+
+> [!NOTE]
+> SharePoint Online resource environments are returned only when this API is called with delegated (app+user) permissions. This scenario isn't supported with application-only permissions. To retrieve SharePoint site information in an app-only context, use the [sites: getAllSites](site-getallsites.md) API, which returns equivalent site information.
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/accesspackagecatalog-list-resources.md
+++ b/api-reference/v1.0/api/accesspackagecatalog-list-resources.md
@@ -5,7 +5,7 @@ ms.localizationpriority: medium
 author: "markwahl-msft"
 ms.subservice: "entra-id-governance"
 doc_type: apiPageType
-ms.date: 03/08/2024
+ms.date: 07/31/2026
 ---
 
 # List resources
@@ -24,6 +24,9 @@ Choose the permission or permissions marked as least privileged for this API. Us
 [!INCLUDE [permissions-table](../includes/permissions/accesspackagecatalog-list-resources-permissions.md)]
 
 [!INCLUDE [rbac-entitlement-catalog-reader](../includes/rbac-for-apis/rbac-entitlement-management-catalog-reader-apis-read.md)]
+
+> [!NOTE]
+> SharePoint Online resources are returned only when this API is called with delegated (app+user) permissions. This scenario isn't supported with application-only permissions. To retrieve SharePoint site information in an app-only context, use the [sites: getAllSites](site-getallsites.md) API, which returns equivalent site information.
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/accesspackagecatalog-list-resources.md
+++ b/api-reference/v1.0/api/accesspackagecatalog-list-resources.md
@@ -26,7 +26,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 [!INCLUDE [rbac-entitlement-catalog-reader](../includes/rbac-for-apis/rbac-entitlement-management-catalog-reader-apis-read.md)]
 
 > [!NOTE]
-> SharePoint Online resources are returned only when this API is called with delegated (app+user) permissions. This scenario isn't supported with application-only permissions. To retrieve SharePoint site information in an app-only context, use the [sites: getAllSites](site-getallsites.md) API, which returns equivalent site information.
+> SharePoint Online resources are returned only when this API is called with delegated permissions. This scenario isn't supported with application permissions. To retrieve SharePoint site information using application permissions, use the [sites: getAllSites](../api/site-getallsites.md) API, which returns equivalent site information.
 
 ## HTTP request
 


### PR DESCRIPTION
Adds a note to two entitlement management API reference topics explaining that SharePoint Online resource flows are supported only with delegated (app+user) permissions, and pointing app-only callers to `sites: getAllSites` for equivalent site information.

## Files changed

- `api-reference/v1.0/api/accesspackagecatalog-list-resources.md`
- `api-reference/beta/api/accesspackageresourceenvironment-get.md`

The note is placed after the permissions/RBAC includes and before the HTTP request section, so the limitation sits next to the permissions guidance it applies to. `ms.date` was updated on both files.

No schema change, so no changelog or What's New entry is included.