### PR TITLE
Update legacy alerts deprecation include dates

### DIFF
--- a/api-reference/beta/includes/security-alerts-v1-deprecation.md
+++ b/api-reference/beta/includes/security-alerts-v1-deprecation.md
@@ -7,4 +7,4 @@ ms.topic: include
 
 <!-- markdownlint-disable MD041-->
 > [!IMPORTANT]
-> The legacy alerts API is deprecated and will be retired on August 31, 2026. Migrate to the new [alerts and incidents](/graph/api/resources/security-alert) API. For more information, see [Migrate from legacy alerts to the alerts and incidents API](/graph/alertsv1-alertsv2-migration).
+> The legacy alerts API is deprecated and will be retired on October 15, 2026. Migrate to the new [alerts and incidents](/graph/api/resources/security-alert) API. For more information, see [Migrate from legacy alerts to the alerts and incidents API](/graph/alertsv1-alertsv2-migration).

--- a/api-reference/v1.0/includes/security-alerts-v1-deprecation.md
+++ b/api-reference/v1.0/includes/security-alerts-v1-deprecation.md
@@ -7,4 +7,4 @@ ms.topic: include
 
 <!-- markdownlint-disable MD041-->
 > [!IMPORTANT]
-> The legacy alerts API is deprecated and will be retired on August 31, 2026. Migrate to the new [alerts and incidents](/graph/api/resources/security-alert) API. For more information, see [Migrate from legacy alerts to the alerts and incidents API](/graph/alertsv1-alertsv2-migration).
+> The legacy alerts API is deprecated and will be retired on October 15, 2026. Migrate to the new [alerts and incidents](/graph/api/resources/security-alert) API. For more information, see [Migrate from legacy alerts to the alerts and incidents API](/graph/alertsv1-alertsv2-migration).


### PR DESCRIPTION
Updates the beta and v1.0 legacy alerts API deprecation include files to change the retirement date from August 31, 2026 to October 15, 2026.

Documentation-only change; no API or schema updates.