### PR TITLE
feat(security): Add createAlert action documentation for M365 Defender alerts

### DIFF
--- a/api-reference/beta/api/security-alert-createalert.md
+++ b/api-reference/beta/api/security-alert-createalert.md
@@ -1,0 +1,204 @@
+---
+title: "alert: createAlert"
+description: "Create a Microsoft 365 Defender alert by invoking a bound action on the alerts_v2 collection."
+author: "a-merberg"
+ms.date: 08/04/2026
+ms.localizationpriority: medium
+ms.subservice: "security"
+doc_type: apiPageType
+---
+
+# alert: createAlert
+
+Namespace: microsoft.graph.security
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Create a Microsoft 365 Defender alert by invoking a bound action on the `alerts_v2` collection and returning the created [alert](../resources/security-alert.md) resource. The action accepts a [createAlertInput](../resources/security-createalertinput.md) complex type that combines alert metadata and creation-specific options in one request object.
+
+## Permissions
+
+Choose the permission or permissions marked as least privileged for this API. Use a higher privileged permission or permissions [only if your app requires it](/graph/permissions-overview#best-practices-for-using-microsoft-graph-permissions). For details about delegated and application permissions, see [Permission types](/graph/permissions-overview#permission-types). To learn more about these permissions, see the [permissions reference](/graph/permissions-reference).
+
+<!-- {
+  "blockType": "permissions",
+  "name": "security-alert-createalert-permissions"
+}
+-->
+[!INCLUDE [permissions-table](../includes/permissions/security-alert-createalert-permissions.md)]
+
+## HTTP request
+
+<!-- {
+  "blockType": "ignored"
+}
+-->
+``` http
+POST /security/alerts_v2/createAlert
+```
+
+## Request headers
+
+|Name|Description|
+|:---|:---|
+|Authorization|Bearer {token}. Required. Learn more about [authentication and authorization](/graph/auth/auth-concepts).|
+|Content-Type|application/json. Required.|
+
+## Request body
+
+In the request body, supply a JSON representation of the parameters.
+
+The following table lists the parameters that are required when you call this action.
+
+|Parameter|Type|Description|
+|:---|:---|:---|
+|createAlertInput|[microsoft.graph.security.createAlertInput](../resources/security-createalertinput.md)|The input containing alert properties, incident-linking options, workspace routing, and inline entity definitions.|
+
+## Response
+
+If successful, this action returns a `201 Created` response code and an [alert](../resources/security-alert.md) object in the response body.
+
+## Examples
+
+### Example 1: Create an alert linked to an existing incident
+
+#### Request
+
+The following example shows a request that creates an alert and links it to incident 42.
+<!-- {
+  "blockType": "request",
+  "name": "alertthis.createalert_linked"
+}
+-->
+``` http
+POST https://graph.microsoft.com/beta/security/alerts_v2/createAlert
+Content-Type: application/json
+
+{
+  "createAlertInput": {
+    "title": "Suspicious PowerShell activity",
+    "severity": "medium",
+    "description": "PowerShell script execution was identified during analyst triage.",
+    "category": "Execution",
+    "recommendedActions": "Review the script contents and isolate the affected device.",
+    "mitreTechniques": ["T1059.001"],
+    "linkToIncident": 42,
+    "isExcludedFromCorrelation": false,
+    "entityDefinitions": [
+      {
+        "entityType": "device",
+        "entityIdentifier": "deviceId",
+        "identifierValue": "d1234567-abcd-efgh-ijkl-890123456789",
+        "role": "impacted"
+      }
+    ]
+  }
+}
+```
+
+#### Response
+
+The following example shows the response.
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.security.alert"
+}
+-->
+``` http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "@odata.type": "#microsoft.graph.security.alert",
+  "id": "ea2c5e5341-c60a-42fc-953f-3da427c85e2d_aml",
+  "providerAlertId": "manual_ea2c5e5341-c60a-42fc-953f-3da427c85e2d",
+  "incidentId": "42",
+  "title": "Suspicious PowerShell activity",
+  "description": "PowerShell script execution was identified during analyst triage.",
+  "severity": "medium",
+  "status": "new",
+  "classification": "unknown",
+  "determination": "unknown",
+  "category": "Execution",
+  "serviceSource": "microsoft365Defender",
+  "detectionSource": "manual",
+  "createdDateTime": "2026-07-27T11:00:00Z",
+  "lastUpdateDateTime": "2026-07-27T11:00:00Z",
+  "recommendedActions": "Review the script contents and isolate the affected device.",
+  "mitreTechniques": ["T1059.001"],
+  "alertWebUrl": "https://security.microsoft.com/alerts/ea2c5e5341-c60a-42fc-953f-3da427c85e2d_aml"
+}
+```
+
+### Example 2: Create an alert with a new incident
+
+#### Request
+
+The following example shows a request that creates an alert without specifying an incident, causing the backend to create a new incident.
+<!-- {
+  "blockType": "request",
+  "name": "alertthis.createalert_new_incident"
+}
+-->
+``` http
+POST https://graph.microsoft.com/beta/security/alerts_v2/createAlert
+Content-Type: application/json
+
+{
+  "createAlertInput": {
+    "title": "Unauthorized access attempt",
+    "severity": "high",
+    "description": "Multiple failed login attempts from an unusual location.",
+    "category": "InitialAccess",
+    "mitreTechniques": ["T1078"],
+    "isExcludedFromCorrelation": false,
+    "entityDefinitions": [
+      {
+        "entityType": "user",
+        "entityIdentifier": "userPrincipalName",
+        "identifierValue": "admin@contoso.com",
+        "role": "impacted"
+      },
+      {
+        "entityType": "ip",
+        "entityIdentifier": "address",
+        "identifierValue": "198.51.100.42",
+        "role": "related"
+      }
+    ]
+  }
+}
+```
+
+#### Response
+
+The following example shows the response.
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.security.alert"
+}
+-->
+``` http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+  "@odata.type": "#microsoft.graph.security.alert",
+  "id": "bf3c9e7812-a45b-44dc-8e2f-1a2b3c4d5e6f_aml",
+  "providerAlertId": "manual_bf3c9e7812-a45b-44dc-8e2f-1a2b3c4d5e6f",
+  "incidentId": "128",
+  "title": "Unauthorized access attempt",
+  "severity": "high",
+  "status": "new",
+  "category": "InitialAccess",
+  "serviceSource": "microsoft365Defender",
+  "detectionSource": "manual",
+  "createdDateTime": "2026-07-27T12:30:00Z",
+  "lastUpdateDateTime": "2026-07-27T12:30:00Z",
+  "alertWebUrl": "https://security.microsoft.com/alerts/bf3c9e7812-a45b-44dc-8e2f-1a2b3c4d5e6f_aml"
+}
+```

--- a/api-reference/beta/includes/permissions/security-alert-createalert-permissions.md
+++ b/api-reference/beta/includes/permissions/security-alert-createalert-permissions.md
@@ -1,0 +1,11 @@
+---
+description: Automatically generated file. DO NOT MODIFY
+ms.topic: include
+ms.localizationpriority: medium
+---
+
+|Permission type|Least privileged permissions|Higher privileged permissions|
+|:---|:---|:---|
+|Delegated (work or school account)|SecurityAlert.Create.All|SecurityAlert.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|Not supported.|
+|Application|SecurityAlert.Create.All|SecurityAlert.ReadWrite.All|

--- a/api-reference/beta/resources/security-createalertinput.md
+++ b/api-reference/beta/resources/security-createalertinput.md
@@ -1,0 +1,64 @@
+---
+title: "createAlertInput resource type"
+description: "Input parameters for the createAlert action that combine alert metadata and creation-specific options in one request object."
+author: "a-merberg"
+ms.date: 08/04/2026
+ms.localizationpriority: medium
+ms.subservice: "security"
+doc_type: resourcePageType
+---
+
+# createAlertInput resource type
+
+Namespace: microsoft.graph.security
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Input parameters for the [createAlert](../api/security-alert-createalert.md) action that combine alert metadata and creation-specific options in one request object. This complex type replaces the [manualAlert](security-manualalert.md) derived-entity request shape and avoids requiring callers to send `@odata.type` annotations.
+
+## Properties
+
+|Property|Type|Description|
+|:---|:---|:---|
+|title|String|Title of the alert. Required.|
+|severity|[microsoft.graph.security.alertSeverity](../resources/enums.md#alertseverity-values)|Severity level of the alert. Required. The possible values are: `unknown`, `informational`, `low`, `medium`, `high`, `unknownFutureValue`.|
+|description|String|Detailed description of the alert. Required.|
+|category|String|MITRE ATT&CK category for the alert. Required.|
+|recommendedActions|String|Recommended remediation actions for the alert. Optional.|
+|mitreTechniques|String collection|MITRE ATT&CK technique identifiers associated with the alert. Optional.|
+|linkToIncident|Int64|Incident ID to link the alert to. Use `0` or omit the value to create a new incident. Optional.|
+|isExcludedFromCorrelation|Boolean|Whether the alert is excluded from automatic correlation. Optional; defaults to `false`.|
+|sentinelWorkspace|String|Microsoft Sentinel workspace identifier used for workspace routing. Optional.|
+|entityDefinitions|[microsoft.graph.security.entityDefinition](../resources/security-entitydefinition.md) collection|Inline entity definitions that associate entities with the alert. Required.|
+
+## Relationships
+
+None.
+
+## JSON representation
+
+The following JSON representation shows the resource type.
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.security.createAlertInput"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.security.createAlertInput",
+  "title": "String",
+  "severity": "String",
+  "description": "String",
+  "category": "String",
+  "recommendedActions": "String",
+  "mitreTechniques": ["String"],
+  "linkToIncident": 0,
+  "isExcludedFromCorrelation": false,
+  "sentinelWorkspace": "String",
+  "entityDefinitions": [
+    {
+      "@odata.type": "microsoft.graph.security.entityDefinition"
+    }
+  ]
+}
+```

--- a/api-reference/beta/resources/security-entitydefinition.md
+++ b/api-reference/beta/resources/security-entitydefinition.md
@@ -1,0 +1,48 @@
+---
+title: "entityDefinition resource type"
+description: "Defines a single entity reference included in createAlertInput for alert creation."
+author: "a-merberg"
+ms.date: 08/04/2026
+ms.localizationpriority: medium
+ms.subservice: "security"
+doc_type: resourcePageType
+---
+
+# entityDefinition resource type
+
+Namespace: microsoft.graph.security
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Defines a single entity reference included in [createAlertInput](../resources/security-createalertinput.md) for alert creation. Each entity definition associates an entity (such as a user, device, or IP address) with the alert being created.
+
+## Properties
+
+|Property|Type|Description|
+|:---|:---|:---|
+|entityType|[microsoft.graph.security.manualAlertEntityType](../resources/enums.md)|The type of entity to associate with the alert. The possible values are: `user`, `device`, `file`, `ip`, `url`, `cloudApplication`, `mailbox`, `securityGroup`, `azureResource`, `amazonResource`, `googleCloudResource`, `oAuthApplication`, `emailMessage`, `emailCluster`, `process`, `registryKey`, `registryValue`, `unknownFutureValue`.|
+|entityIdentifier|String|The identifier kind for the selected entity type, such as `userPrincipalName`, `deviceId`, or `address`.|
+|identifierValue|String|The value for the selected entity identifier.|
+|role|[microsoft.graph.security.entityDefinitionInputRole](../resources/enums.md)|Whether the entity is an impacted asset or related evidence. The possible values are: `impacted`, `related`, `unknownFutureValue`.|
+
+## Relationships
+
+None.
+
+## JSON representation
+
+The following JSON representation shows the resource type.
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.security.entityDefinition"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.security.entityDefinition",
+  "entityType": "String",
+  "entityIdentifier": "String",
+  "identifierValue": "String",
+  "role": "String"
+}
+```


### PR DESCRIPTION
Add documentation for the new `createAlert` bound action on the `alerts_v2` collection in the Microsoft Graph Security API (beta).

## Changes
- New API reference: `security-alert-createalert.md` — describes the createAlert action with examples
- New resource: `security-createalertinput.md` — input complex type for the action
- New resource: `security-entitydefinition.md` — entity definition complex type
- New permissions include: `security-alert-createalert-permissions.md`

## Related
- Schema publication PR: https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/16677904
- API Review PR (merged): https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/16526598
- Backend PR: https://dev.azure.com/microsoft/WDATP/_git/USE.PublicGraphApi/pullrequest/16243363
- Work item: AB#51168