### PR TITLE
Fix example intro sentences beta

### DIFF
--- a/api-reference/beta/api/accesspackage-delete-accesspackageresourcerolescopes.md
+++ b/api-reference/beta/api/accesspackage-delete-accesspackageresourcerolescopes.md
@@ -53,7 +53,7 @@ If successful, this method returns a 200-series response code. It doesn't return
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 <!-- {
   "blockType": "request",
@@ -67,7 +67,7 @@ DELETE https://graph.microsoft.com/beta/identityGovernance/entitlementManagement
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/authenticationcontextclassreference-update.md
+++ b/api-reference/beta/api/authenticationcontextclassreference-update.md
@@ -64,7 +64,7 @@ If successful, this method returns a `204 No Content` response code. It doesn't 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 # [HTTP](#tab/http)
@@ -119,7 +119,7 @@ Content-type: application/json
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/bookingbusiness-list-calendarview.md
+++ b/api-reference/beta/api/bookingbusiness-list-calendarview.md
@@ -57,9 +57,9 @@ Don't supply a request body for this method.
 If successful, this method returns a `200 OK` response code and a collection of [bookingAppointment](../resources/bookingappointment.md) objects in the response body.
 
 ## Example
-Here's an example  of how to call this API.
+
 ### Request
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -98,7 +98,7 @@ GET https://graph.microsoft.com/beta/solutions/bookingbusinesses/contosolunchdel
 ---
 
 ### Response
-Here's an example  of the response.
+The following example shows the response.
 
 >**Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/certificatebasedauthconfiguration-delete.md
+++ b/api-reference/beta/api/certificatebasedauthconfiguration-delete.md
@@ -53,7 +53,7 @@ If successful, this method returns `204 No Content` response code. It doesn't re
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -97,7 +97,7 @@ DELETE https://graph.microsoft.com/beta/organization/{id}/certificateBasedAuthCo
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/chart-delete.md
+++ b/api-reference/beta/api/chart-delete.md
@@ -43,7 +43,7 @@ DELETE /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/charts/{name}
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 
@@ -83,7 +83,7 @@ DELETE https://graph.microsoft.com/beta/me/drive/items/{id}/workbook/worksheets/
 ---
 
 ### Response
-The following example shows the response. 
+The following example shows the response.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/beta/api/chart-image.md
+++ b/api-reference/beta/api/chart-image.md
@@ -51,7 +51,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and base-64 image string in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/chart-setdata.md
+++ b/api-reference/beta/api/chart-setdata.md
@@ -50,7 +50,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 
@@ -96,7 +96,7 @@ Content-type: application/json
 ---
 
 ### Response
-The following example shows the response. 
+The following example shows the response.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/beta/api/chart-setposition.md
+++ b/api-reference/beta/api/chart-setposition.md
@@ -50,7 +50,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/chartcollection-add.md
+++ b/api-reference/beta/api/chartcollection-add.md
@@ -51,7 +51,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookChart](../resources/workbookchart.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/chartcollection-itemat.md
+++ b/api-reference/beta/api/chartcollection-itemat.md
@@ -54,7 +54,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookChart](../resources/workbookchart.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/chartfill-clear.md
+++ b/api-reference/beta/api/chartfill-clear.md
@@ -48,7 +48,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/charts/{name}/le
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/chartfill-setsolidcolor.md
+++ b/api-reference/beta/api/chartfill-setsolidcolor.md
@@ -53,7 +53,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/chartlineformat-clear.md
+++ b/api-reference/beta/api/chartlineformat-clear.md
@@ -48,7 +48,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/charts/{name}/ax
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/chartpointscollection-itemat.md
+++ b/api-reference/beta/api/chartpointscollection-itemat.md
@@ -54,7 +54,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookChartPoint](../resources/workbookchartpoint.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/chartseriescollection-itemat.md
+++ b/api-reference/beta/api/chartseriescollection-itemat.md
@@ -54,7 +54,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookChartSeries](../resources/workbookchartseries.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/checklistitem-get.md
+++ b/api-reference/beta/api/checklistitem-get.md
@@ -71,7 +71,7 @@ If successful, this method returns a `200 OK` response code and a [checklistItem
 
 ### Request 1 
 
-Here is an example to get a **checklistItem** associated to a **todoTask**.
+The following example shows how to get a **checklistItem** associated to a **todoTask**.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -138,7 +138,7 @@ Content-Type: application/json
 
 ### Request 2
 
-Here is an example to get a **checklistItem** associated to a **baseTask** (deprecated).
+The following example shows how to get a **checklistItem** associated to a **baseTask** (deprecated).
 
 # [HTTP](#tab/http)
 <!-- {

--- a/api-reference/beta/api/checklistitem-update.md
+++ b/api-reference/beta/api/checklistitem-update.md
@@ -79,7 +79,7 @@ If successful, this method returns a `200 OK` response code and an updated [chec
 
 ### Request 1
 
-Here is an example to update a **checklistItem** associated to a **todoTask**.
+The following example shows how to update a **checklistItem** associated to a **todoTask**.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -151,7 +151,7 @@ Content-Type: application/json
 
 ### Request 2
 
-Here is an example to update a **checklistItem** associated to a **baseTask** (deprecated).
+The following example shows how to update a **checklistItem** associated to a **baseTask** (deprecated).
 
 # [HTTP](#tab/http)
 <!-- {

--- a/api-reference/beta/api/connector-list-memberof.md
+++ b/api-reference/beta/api/connector-list-memberof.md
@@ -43,7 +43,7 @@ Don't supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [connectorGroup](../resources/connectorgroup.md) objects in the response body.
 ## Example
 ### Request
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -85,7 +85,9 @@ GET https://graph.microsoft.com/beta/onPremisesPublishingProfiles/applicationPro
 ---
 
 ### Response
-Here's an example  of the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/beta/api/connectorgroup-list.md
+++ b/api-reference/beta/api/connectorgroup-list.md
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and collection of [c
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -89,7 +89,9 @@ GET https://graph.microsoft.com/beta/onPremisesPublishingProfiles/applicationPro
 ---
 
 ### Response
-Here's an example  of the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/beta/api/conversationthread-reply.md
+++ b/api-reference/beta/api/conversationthread-reply.md
@@ -52,7 +52,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `202 Accepted` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/directory-post-customsecurityattributedefinitions.md
+++ b/api-reference/beta/api/directory-post-customsecurityattributedefinitions.md
@@ -256,7 +256,7 @@ Content-Type: application/json
 
 ### Example 3: Add a custom security attribute with a list of predefined values
 
-Here's an example that adds a new custom security attribute definition with a list of predefined values as a collection of strings.
+The following example shows how to add a new custom security attribute definition with a list of predefined values as a collection of strings.
 
 + Attribute set: `Engineering`
 + Attribute: `Project`

--- a/api-reference/beta/api/directoryobject-delta.md
+++ b/api-reference/beta/api/directoryobject-delta.md
@@ -158,7 +158,7 @@ GET https://graph.microsoft.com/beta/directoryObjects/delta?filter=isof('microso
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization with `$filter=isof('{resource type}')`. Note the presence of the _members@delta_ property that includes the IDs of member objects in the group.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization with `$filter=isof('{resource type}')`. Note the presence of the _members@delta_ property that includes the IDs of member objects in the group.
 
 > **Note:** The response object shown here might be shortened for readability.
 
@@ -265,7 +265,7 @@ GET https://graph.microsoft.com/beta/directoryObjects/delta?$filter=id eq '87d34
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization with `$filter=id eq '{id}'`.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization with `$filter=id eq '{id}'`.
 
 > **Note:** The response object shown here might be shortened for readability.
 <!-- {
@@ -356,7 +356,7 @@ GET https://graph.microsoft.com/beta/directoryObjects/delta?$filter=isof('micros
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization. Both properties are included in the response and it isn't known which ones have changed since the `@odata.deltaLink` was obtained.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization. Both properties are included in the response and it isn't known which ones have changed since the `@odata.deltaLink` was obtained.
 
 <!-- {
   "blockType": "response",
@@ -436,7 +436,7 @@ Prefer: return=minimal
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization. The `microsoft.graph.user/surname` property isn't included, which means it hasn't changed since the last delta query; `microsoft.graph.group/displayName` is included which means its value has changed.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization. The `microsoft.graph.user/surname` property isn't included, which means it hasn't changed since the last delta query; `microsoft.graph.group/displayName` is included which means its value has changed.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/driveitem-delta.md
+++ b/api-reference/beta/api/driveitem-delta.md
@@ -82,11 +82,11 @@ In addition to the collection of DriveItems, the response also includes one of t
 
 ### Example 1: Initial request
 
-Here's an example of how to call this API to establish your local state.
+The following example shows how to call this API to establish your local state.
 
 #### Request
 
-Here's an example of the initial request.
+The following example shows the initial request.
 
 
 # [HTTP](#tab/http)

--- a/api-reference/beta/api/driveitem-list-versions.md
+++ b/api-reference/beta/api/driveitem-list-versions.md
@@ -51,10 +51,10 @@ If successful, this method returns a `200 OK` response code and collection of [D
 
 ## Example
 
-Here's and example the retrieves the versions of a file in the current user's drive.
 
 ### Request
 
+The following example shows how to retrieve the versions of a file in the current user's drive.
 
 # [HTTP](#tab/http)
 <!-- { "blockType": "request", "name": "get-previous-versions", "scopes": "files.read" } -->
@@ -95,7 +95,7 @@ GET /me/drive/items/{item-id}/versions
 
 ### Response
 
-Here's an example of the response that includes a collection of versions:
+The following example shows the response that includes a collection of versions.
 
 <!-- { "blockType": "response", "@odata.type": "Collection(microsoft.graph.driveItemVersion)", "truncated": true } -->
 

--- a/api-reference/beta/api/event-accept.md
+++ b/api-reference/beta/api/event-accept.md
@@ -58,7 +58,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `202 Accepted` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/event-cancel.md
+++ b/api-reference/beta/api/event-cancel.md
@@ -68,7 +68,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `202 Accepted` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/event-decline.md
+++ b/api-reference/beta/api/event-decline.md
@@ -75,7 +75,7 @@ This action returns HTTP 400 if one or both of the following occur:
 
 ## Example
 
-Here is an example of how to call this API.
+The following example shows how to call this API.
 
 ### Request
 

--- a/api-reference/beta/api/event-dismissreminder.md
+++ b/api-reference/beta/api/event-dismissreminder.md
@@ -54,7 +54,7 @@ If successful, this method returns a `200 OK` response code. It doesn't return a
 
 ## Example
 
-Here is an example of how to call this API.
+The following example shows how to call this API.
 
 ### Request
 The following example shows a request.

--- a/api-reference/beta/api/event-forward.md
+++ b/api-reference/beta/api/event-forward.md
@@ -66,7 +66,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `202 Accepted` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/event-post-attachments.md
+++ b/api-reference/beta/api/event-post-attachments.md
@@ -146,7 +146,7 @@ Content-Length: 735
 
 ### Request
 
-Here is an example which attaches an event with another event as an item attachment.
+The following example shows a request that attaches an event with another event as an item attachment.
 
 
 # [HTTP](#tab/http)
@@ -301,7 +301,7 @@ Content-type: application/json
 
 ### Response
 
-Here is an example of a full response.
+The following example shows a full response.
 <!-- {
   "blockType": "response",
   "name": "create_reference_attachment_from_event",

--- a/api-reference/beta/api/event-snoozereminder.md
+++ b/api-reference/beta/api/event-snoozereminder.md
@@ -57,7 +57,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/event-tentativelyaccept.md
+++ b/api-reference/beta/api/event-tentativelyaccept.md
@@ -66,7 +66,7 @@ This action returns HTTP 400 if one or both of the following occur:
 - The **proposedNewTime** parameter is included but the **sendResponse** parameter is set to `false`.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 In the following example, the signed-in user responds tentative to the specified event, sets the **sendResponse** parameter to true, and includes an alternative time in the **proposedNewTime** parameter.
 

--- a/api-reference/beta/api/group-delta.md
+++ b/api-reference/beta/api/group-delta.md
@@ -152,7 +152,7 @@ GET https://graph.microsoft.com/beta/groups/delta
 
 #### Response 1
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization.
 
 > **Note:** The response object shown here might be shortened for readability.
 >
@@ -243,7 +243,7 @@ GET https://graph.microsoft.com/beta/groups/delta?$select=displayName,descriptio
 
 #### Response 2
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization. All three properties are included in the response and it isn't known which ones have changed since the `@odata.deltaLink` was obtained.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization. All three properties are included in the response and it isn't known which ones have changed since the `@odata.deltaLink` was obtained.
 
 <!-- {
   "blockType": "response",
@@ -317,7 +317,7 @@ Prefer: return=minimal
 
 #### Response 3
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization. The `mailNickname` property isn't included, which means it hasn't changed since the last delta query; `displayName` and `description` are included which means their values have changed.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization. The `mailNickname` property isn't included, which means it hasn't changed since the last delta query; `displayName` and `description` are included which means their values have changed.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/group-get.md
+++ b/api-reference/beta/api/group-get.md
@@ -68,7 +68,7 @@ If successful, this method returns a `200 OK` response code and [group](../resou
 
 #### Request
 
-Here's an example  of a GET request.
+The following example shows a GET request.
 
 # [HTTP](#tab/http)
 
@@ -114,7 +114,7 @@ GET https://graph.microsoft.com/beta/groups/45b7d2e7-b882-4a80-ba97-10b7a63b8fa4
 
 #### Response
 
-Here's an example  of the response. It includes only the default properties.
+The following example shows the response. It includes only the default properties.
 
 > **Note:** The response object shown here might be shortened for readability. All the default properties are returned in an actual call.
 
@@ -184,7 +184,7 @@ Content-type: application/json
 
 #### Request
 
-Here's an example  of a GET request.
+The following example shows a GET request.
 
 # [HTTP](#tab/http)
 
@@ -230,7 +230,7 @@ GET https://graph.microsoft.com/beta/groups/b320ee12-b1cd-4cca-b648-a437be61c5cd
 
 #### Response
 
-Here's an example  of the response that includes the requested nondefault properties.
+The following example shows the response that includes the requested nondefault properties.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/identitycontainer-post-b2cuserflows.md
+++ b/api-reference/beta/api/identitycontainer-post-b2cuserflows.md
@@ -65,7 +65,7 @@ If successful, this method returns a `201 Created` response code and a Location 
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -117,7 +117,7 @@ Content-type: application/json
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 **Note:** The response object shown here might be shortened for readability.
 
@@ -151,7 +151,7 @@ Content-type: application/json
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -209,7 +209,7 @@ Content-type: application/json
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 **Note:** The response object shown here might be shortened for readability.
 
@@ -242,7 +242,7 @@ Content-type: application/json
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 # [HTTP](#tab/http)
@@ -303,7 +303,7 @@ Content-type: application/json
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/identityuserflow-get.md
+++ b/api-reference/beta/api/identityuserflow-get.md
@@ -54,7 +54,7 @@ If successful, this method returns a `200 OK` response code and the requested [u
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -99,7 +99,7 @@ GET https://graph.microsoft.com/beta/identity/userFlows/B2C_1_Pol1
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/listitem-create.md
+++ b/api-reference/beta/api/listitem-create.md
@@ -38,7 +38,7 @@ In the request body, supply a JSON representation of the [listItem][] resource t
 
 ## Example
 
-Here is an example of how to create a new generic list item.
+The following example shows how to create a new generic list item.
 
 
 # [HTTP](#tab/http)

--- a/api-reference/beta/api/listitem-update.md
+++ b/api-reference/beta/api/listitem-update.md
@@ -45,7 +45,7 @@ In the request body, supply a JSON representation of a [fieldValueSet][] specify
 
 ## Example
 
-Here is an example that updates the Color and Quantity fields of the list item with new values.
+The following example shows a request that updates the Color and Quantity fields of the list item with new values.
 All other values on the listItem are left alone.
 
 

--- a/api-reference/beta/api/mailfolder-copy.md
+++ b/api-reference/beta/api/mailfolder-copy.md
@@ -55,7 +55,7 @@ If successful, this method returns `200 OK` response code and a [mailFolder](../
 
 ## Example
 
-Here's an example of how to call this API.
+The following example shows how to call this API.
 
 ### Request
 

--- a/api-reference/beta/api/mailfolder-move.md
+++ b/api-reference/beta/api/mailfolder-move.md
@@ -55,7 +55,7 @@ If successful, this method returns `200 OK` response code and a [mailFolder](../
 
 ## Example
 
-Here's an example of how to call this API.
+The following example shows how to call this API.
 
 ### Request
 

--- a/api-reference/beta/api/message-copy.md
+++ b/api-reference/beta/api/message-copy.md
@@ -57,7 +57,7 @@ If successful, this method returns `201 Created` response code and a [message](.
 
 ## Example
 
-Here is an example of how to call this API.
+The following example shows how to call this API.
 
 ### Request
 

--- a/api-reference/beta/api/message-move.md
+++ b/api-reference/beta/api/message-move.md
@@ -57,7 +57,7 @@ If successful, this method returns `201 Created` response code and a [message](.
 
 ## Example
 
-Here is an example of how to call this API.
+The following example shows how to call this API.
 
 ### Request
 

--- a/api-reference/beta/api/message-post-attachments.md
+++ b/api-reference/beta/api/message-post-attachments.md
@@ -302,7 +302,7 @@ Content-type: application/json
 ---
 
 ### Response
-Here is an example of a full response.
+The following example shows a full response.
 <!-- {
   "blockType": "response",
   "name": "create_reference_attachment_from_message",

--- a/api-reference/beta/api/message-send.md
+++ b/api-reference/beta/api/message-send.md
@@ -56,7 +56,7 @@ If successful, this method returns `202 Accepted` response code. It doesn't retu
 ## Examples
 ### Example 1: Send an existing draft message
 
-Here is an example of how to call this API.
+The following example shows how to call this API.
 
 ##### Request
 

--- a/api-reference/beta/api/message-unsubscribe.md
+++ b/api-reference/beta/api/message-unsubscribe.md
@@ -52,7 +52,7 @@ Don't supply a request body for this method.
 If successful, this method returns `202 Accepted` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/nameditem-add.md
+++ b/api-reference/beta/api/nameditem-add.md
@@ -53,7 +53,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookNamedItem](../resources/workbooknameditem.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 
 ### Request
 The following example shows a request.

--- a/api-reference/beta/api/nameditem-addformulalocal.md
+++ b/api-reference/beta/api/nameditem-addformulalocal.md
@@ -51,7 +51,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [NamedItem](../resources/workbooknameditem.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 
 ### Request
 The following example shows a request.

--- a/api-reference/beta/api/nameditem-range.md
+++ b/api-reference/beta/api/nameditem-range.md
@@ -44,7 +44,7 @@ GET /me/drive/root:/{item-path}:/workbook/names/{name}/range
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/networkaccess-conditionalaccesssettings-get.md
+++ b/api-reference/beta/api/networkaccess-conditionalaccesssettings-get.md
@@ -53,7 +53,7 @@ If successful, this method returns a `200 OK` response code and a [microsoft.gra
 ## Examples
 
 ### Request
-Here's an example  of a request.
+The following example shows a request.
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -95,7 +95,7 @@ GET https://graph.microsoft.com/beta/networkAccess/settings/conditionalAccess
 ---
 
 ### Response
-Here's an example  of the response.
+The following example shows the response.
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/notebook-copynotebook.md
+++ b/api-reference/beta/api/notebook-copynotebook.md
@@ -55,7 +55,7 @@ In the request body, provide a JSON object that contains the parameters that you
 If successful, this method returns a `202 Accepted` response code and an `Operation-Location` header. Poll the Operation-Location endpoint to [get the status of the copy operation](onenoteoperation-get.md).
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/notifications-post.md
+++ b/api-reference/beta/api/notifications-post.md
@@ -94,7 +94,7 @@ Content-type: application/json
 ```
 
 ### Response
-Here's an example of the corresponding response.
+The following example shows the corresponding response.
 
 ```http
 HTTP/1.1 201

--- a/api-reference/beta/api/orgcontact-delta.md
+++ b/api-reference/beta/api/orgcontact-delta.md
@@ -150,7 +150,7 @@ GET https://graph.microsoft.com/beta/contacts/delta
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization.
 
 >**Note:** The response object shown here might be shortened for readability.
 
@@ -233,7 +233,7 @@ GET https://graph.microsoft.com/beta/contacts/delta?$select=displayName,jobTitle
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization. All three properties are included in the response and it isn't known which ones have changed since the `@odata.deltaLink` was obtained.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization. All three properties are included in the response and it isn't known which ones have changed since the `@odata.deltaLink` was obtained.
 
 <!-- {
   "blockType": "response",
@@ -309,7 +309,7 @@ Prefer: return=minimal
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization. The `mail` property isn't included, which means it hasn't changed since the last delta query; `displayName` and `jobTitle` are included, which means their values have changed.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization. The `mail` property isn't included, which means it hasn't changed since the last delta query; `displayName` and `jobTitle` are included, which means their values have changed.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/outlooktask-post-attachments.md
+++ b/api-reference/beta/api/outlooktask-post-attachments.md
@@ -144,7 +144,7 @@ HTTP 201 Created
 
 #### Request
 
-Here is an example which attaches an event with another event as an item attachment.
+The following example shows a request that attaches an event with another event as an item attachment.
 
 
 # [HTTP](#tab/http)

--- a/api-reference/beta/api/outlookuser-supportedlanguages.md
+++ b/api-reference/beta/api/outlookuser-supportedlanguages.md
@@ -47,7 +47,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and a collection of [localeInfo](../resources/localeinfo.md) objects in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/personname-update.md
+++ b/api-reference/beta/api/personname-update.md
@@ -71,7 +71,7 @@ If successful, this method returns a `200 OK` response code and an updated [pers
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -121,7 +121,7 @@ Content-type: application/json
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/post-forward.md
+++ b/api-reference/beta/api/post-forward.md
@@ -50,7 +50,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/post-reply.md
+++ b/api-reference/beta/api/post-reply.md
@@ -53,7 +53,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `202 Accepted` response code. It doesn't return a response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/printershare-get.md
+++ b/api-reference/beta/api/printershare-get.md
@@ -121,7 +121,8 @@ Content-type: application/json
 }
 ```
 
-Here's an example of the response, when using $select=id,displayName,capabilities
+The following example shows the response, when using `$select=id,displayName,capabilities`
+
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/profile-list-accounts.md
+++ b/api-reference/beta/api/profile-list-accounts.md
@@ -66,7 +66,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 # [HTTP](#tab/http)
@@ -111,7 +111,7 @@ GET https://graph.microsoft.com/beta/me/profile/account
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-educationalactivities.md
+++ b/api-reference/beta/api/profile-list-educationalactivities.md
@@ -64,7 +64,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -108,7 +108,7 @@ GET https://graph.microsoft.com/beta/me/profile/educationalActivities
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-interests.md
+++ b/api-reference/beta/api/profile-list-interests.md
@@ -65,7 +65,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -109,7 +109,7 @@ GET https://graph.microsoft.com/beta/me/profile/interests
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-languages.md
+++ b/api-reference/beta/api/profile-list-languages.md
@@ -64,7 +64,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -108,7 +108,7 @@ GET https://graph.microsoft.com/beta/me/profile/languages
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-names.md
+++ b/api-reference/beta/api/profile-list-names.md
@@ -65,7 +65,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -109,7 +109,7 @@ GET https://graph.microsoft.com/beta/me/profile/names
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-positions.md
+++ b/api-reference/beta/api/profile-list-positions.md
@@ -64,7 +64,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -108,7 +108,7 @@ GET https://graph.microsoft.com/beta/me/profile/positions
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-projects.md
+++ b/api-reference/beta/api/profile-list-projects.md
@@ -64,7 +64,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -108,7 +108,7 @@ GET https://graph.microsoft.com/beta/me/profile/projects
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-skills.md
+++ b/api-reference/beta/api/profile-list-skills.md
@@ -65,7 +65,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -109,7 +109,7 @@ GET https://graph.microsoft.com/beta/me/profile/skills
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-webaccounts.md
+++ b/api-reference/beta/api/profile-list-webaccounts.md
@@ -64,7 +64,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -108,7 +108,7 @@ GET https://graph.microsoft.com/beta/me/profile/webAccounts
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/profile-list-websites.md
+++ b/api-reference/beta/api/profile-list-websites.md
@@ -64,7 +64,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -108,7 +108,7 @@ GET https://graph.microsoft.com/beta/me/profile/websites
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/projectrome-get-recent-activities.md
+++ b/api-reference/beta/api/projectrome-get-recent-activities.md
@@ -69,7 +69,7 @@ If successful, this method returns the `200 OK` response code with the user's re
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 <!-- {
   "blockType": "ignored",
@@ -82,7 +82,7 @@ GET https://graph.microsoft.com/beta/me/activities/recent
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- {
   "blockType": "ignored",

--- a/api-reference/beta/api/publishedresource-update.md
+++ b/api-reference/beta/api/publishedresource-update.md
@@ -57,7 +57,7 @@ If successful, this method returns a `204 No Content` response code.
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -105,7 +105,7 @@ PATCH https://graph.microsoft.com/beta/onPremisesPublishingProfiles/provisioning
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/range-boundingrect.md
+++ b/api-reference/beta/api/range-boundingrect.md
@@ -51,7 +51,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 <!-- {

--- a/api-reference/beta/api/range-cell.md
+++ b/api-reference/beta/api/range-cell.md
@@ -51,7 +51,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 <!-- {

--- a/api-reference/beta/api/range-clear.md
+++ b/api-reference/beta/api/range-clear.md
@@ -53,7 +53,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/range-column.md
+++ b/api-reference/beta/api/range-column.md
@@ -50,7 +50,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 <!-- {

--- a/api-reference/beta/api/range-delete.md
+++ b/api-reference/beta/api/range-delete.md
@@ -53,9 +53,9 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `204 No Content` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
-This example shows how to delete a cell and shift the other cells up.
+The following example shows how to delete a cell and shift the other cells up.
 
 # [HTTP](#tab/http)
 <!-- {

--- a/api-reference/beta/api/range-entirecolumn.md
+++ b/api-reference/beta/api/range-entirecolumn.md
@@ -48,7 +48,7 @@ GET /me/drive/root:/{item-path}:/workbook/tables/{id|name}/columns/{id|name}/ran
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/range-entirerow.md
+++ b/api-reference/beta/api/range-entirerow.md
@@ -48,7 +48,7 @@ GET /me/drive/root:/{item-path}:/workbook/tables/{id|name}/columns/{id|name}/ran
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/range-insert.md
+++ b/api-reference/beta/api/range-insert.md
@@ -53,7 +53,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 This example shows how to insert a cell into the worksheet and shift the other cells down.
 

--- a/api-reference/beta/api/range-intersection.md
+++ b/api-reference/beta/api/range-intersection.md
@@ -50,7 +50,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [Range](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 <!-- {

--- a/api-reference/beta/api/range-lastcell.md
+++ b/api-reference/beta/api/range-lastcell.md
@@ -48,7 +48,7 @@ GET /me/drive/root:/{item-path}:/workbook/tables/{id|name}/columns/{id|name}/ran
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/range-lastcolumn.md
+++ b/api-reference/beta/api/range-lastcolumn.md
@@ -48,7 +48,7 @@ GET /me/drive/root:/{item-path}:/workbook/tables/{id|name}/columns/{id|name}/ran
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/range-lastrow.md
+++ b/api-reference/beta/api/range-lastrow.md
@@ -48,7 +48,7 @@ GET /me/drive/root:/{item-path}:/workbook/tables/{id|name}/columns/{id|name}/ran
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/range-merge.md
+++ b/api-reference/beta/api/range-merge.md
@@ -53,7 +53,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/range-offsetrange.md
+++ b/api-reference/beta/api/range-offsetrange.md
@@ -51,7 +51,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 <!-- {

--- a/api-reference/beta/api/range-row.md
+++ b/api-reference/beta/api/range-row.md
@@ -50,7 +50,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 <!-- {

--- a/api-reference/beta/api/range-usedrange.md
+++ b/api-reference/beta/api/range-usedrange.md
@@ -53,7 +53,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/rangebordercollection-itemat.md
+++ b/api-reference/beta/api/rangebordercollection-itemat.md
@@ -55,7 +55,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRangeBorder](../resources/workbookrangeborder.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/rangefill-clear.md
+++ b/api-reference/beta/api/rangefill-clear.md
@@ -45,7 +45,7 @@ POST /me/drive/root:/{item-path}:/workbook/tables/{id|name}/columns/{id|name}/ra
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/rangeformat-autofitcolumns.md
+++ b/api-reference/beta/api/rangeformat-autofitcolumns.md
@@ -45,7 +45,7 @@ POST /me/drive/root:/{item-path}:/workbook/tables/{id|name}/columns/{id|name}/ra
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/rangeformat-autofitrows.md
+++ b/api-reference/beta/api/rangeformat-autofitrows.md
@@ -45,7 +45,7 @@ POST /me/drive/root:/{item-path}:/workbook/tables/{id|name}/columns/{id|name}/ra
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/rangesort-apply.md
+++ b/api-reference/beta/api/rangesort-apply.md
@@ -54,7 +54,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/reportroot-getazureadapplicationsigninsummary.md
+++ b/api-reference/beta/api/reportroot-getazureadapplicationsigninsummary.md
@@ -52,7 +52,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Example
 
 ### Request
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -94,7 +94,7 @@ GET https://graph.microsoft.com/beta/reports/getAzureADApplicationSignInSummary(
 ---
 
 ### Response
-Here's an example  of the response.
+The following example shows the response.
 
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {

--- a/api-reference/beta/api/reportroot-getbrowserdistributionusercounts.md
+++ b/api-reference/beta/api/reportroot-getbrowserdistributionusercounts.md
@@ -85,7 +85,7 @@ Here's an example  that outputs CSV.
 
 #### Request
 
-Here's an example  of a request.
+The following example shows a request.
 
 <!-- {
   "blockType": "ignored",
@@ -97,7 +97,7 @@ GET https://graph.microsoft.com/beta/reports/getBrowserDistributionUserCounts(pe
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- { "blockType": "response" } -->
 ```http
@@ -126,7 +126,7 @@ Here's an example  that returns JSON.
 
 #### Request
 
-Here's an example  of a request.
+The following example shows a request.
 
 <!-- {
   "blockType": "ignored",
@@ -138,7 +138,7 @@ GET https://graph.microsoft.com/beta/reports/getBrowserDistributionUserCounts(pe
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/reportroot-getbrowserusercounts.md
+++ b/api-reference/beta/api/reportroot-getbrowserusercounts.md
@@ -86,7 +86,7 @@ Here's an example  that outputs CSV.
 
 #### Request
 
-Here's an example  of a request.
+The following example shows a request.
 
 <!-- {
   "blockType": "ignored",
@@ -98,7 +98,7 @@ GET https://graph.microsoft.com/beta/reports/getBrowserUserCounts(period='D7')?$
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- { "blockType": "response" } -->
 ```http
@@ -127,7 +127,7 @@ Here's an example  that returns JSON.
 
 #### Request
 
-Here's an example  of a request.
+The following example shows a request.
 
 <!-- {
   "blockType": "ignored",
@@ -139,7 +139,7 @@ GET https://graph.microsoft.com/beta/reports/getBrowserUserCounts(period='D7')?$
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/reportroot-getformsuseractivityuserdetail.md
+++ b/api-reference/beta/api/reportroot-getformsuseractivityuserdetail.md
@@ -85,7 +85,7 @@ Here's an example  that outputs CSV.
 
 #### Request
 
-Here's an example  of a request.
+The following example shows a request.
 
 <!-- {
   "blockType": "ignored",
@@ -98,7 +98,7 @@ GET https://graph.microsoft.com/beta/reports/getFormsUserActivityUserDetail
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- { "blockType": "response" } -->
 ```http
@@ -127,7 +127,7 @@ Here's an example  that returns JSON.
 
 #### Request
 
-Here's an example  of a request.
+The following example shows a request.
 
 <!-- {
   "blockType": "ignored",
@@ -139,7 +139,7 @@ GET https://graph.microsoft.com/beta/reports/getFormsUserActivityUserDetail(peri
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/reportroot-getoffice365groupsactivitydetail.md
+++ b/api-reference/beta/api/reportroot-getoffice365groupsactivitydetail.md
@@ -119,7 +119,7 @@ Here's an example  that outputs CSV.
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 <!-- {
@@ -134,7 +134,7 @@ GET https://graph.microsoft.com/beta/reports/getOffice365GroupsActivityDetail(pe
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- { "blockType": "ignored" } --> 
 
@@ -165,7 +165,7 @@ Here's an example  that returns JSON.
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 <!-- {
@@ -180,7 +180,7 @@ GET https://graph.microsoft.com/beta/reports/getOffice365GroupsActivityDetail(pe
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/reportroot-getoffice365servicesusercounts.md
+++ b/api-reference/beta/api/reportroot-getoffice365servicesusercounts.md
@@ -106,7 +106,7 @@ Here's an example  that outputs CSV.
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 <!-- {
@@ -121,7 +121,7 @@ GET https://graph.microsoft.com/beta/reports/getOffice365ServicesUserCounts(peri
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- { "blockType": "ignored" } --> 
 
@@ -152,7 +152,7 @@ Here's an example  that returns JSON.
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 <!-- {
@@ -167,7 +167,7 @@ GET https://graph.microsoft.com/beta/reports/getOffice365ServicesUserCounts(peri
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/reportroot-getsharepointsiteusagedetail.md
+++ b/api-reference/beta/api/reportroot-getsharepointsiteusagedetail.md
@@ -105,7 +105,7 @@ Here's an example  that outputs CSV.
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 <!-- {
@@ -120,7 +120,7 @@ GET https://graph.microsoft.com/beta/reports/getSharePointSiteUsageDetail(period
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- { "blockType": "ignored" } --> 
 
@@ -151,7 +151,7 @@ Here's an example  that returns JSON.
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 <!-- {
@@ -166,7 +166,7 @@ GET https://graph.microsoft.com/beta/reports/getSharePointSiteUsageDetail(period
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/reportroot-getteamsuseractivitytotaldistributioncounts.md
+++ b/api-reference/beta/api/reportroot-getteamsuseractivitytotaldistributioncounts.md
@@ -94,7 +94,7 @@ Here's an example  that outputs CSV.
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 <!-- {
@@ -109,7 +109,7 @@ GET https://graph.microsoft.com/beta/reports/getTeamsUserActivityTotalDistributi
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- { "blockType": "ignored" } --> 
 
@@ -140,7 +140,7 @@ Here's an example  that returns JSON.
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 <!-- {
@@ -155,7 +155,7 @@ GET https://graph.microsoft.com/beta/reports/getTeamsUserActivityTotalDistributi
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/schedule-share.md
+++ b/api-reference/beta/api/schedule-share.md
@@ -65,7 +65,7 @@ If successful, this method returns a `200 OK` response code. It doesn't return a
 
 #### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -115,7 +115,7 @@ Content-type: application/json
 
 #### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- {
   "blockType": "response"

--- a/api-reference/beta/api/schemaextension-get.md
+++ b/api-reference/beta/api/schemaextension-get.md
@@ -45,7 +45,7 @@ Don't supply a request body for this method.
 If successful, this method returns a `200 OK` response code and [schemaExtension](../resources/schemaextension.md) object in the response body.
 ## Example
 ### Request
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -88,7 +88,9 @@ GET https://graph.microsoft.com/beta/schemaExtensions/graphlearn_test
 ---
 
 ### Response
-Here's an example  of the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. 
+
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/beta/api/section-copytonotebook.md
+++ b/api-reference/beta/api/section-copytonotebook.md
@@ -56,7 +56,7 @@ In the request body, provide a JSON object that contains the parameters that you
 If successful, this method returns a `202 Accepted` response code and an `Operation-Location` header. Poll the Operation-Location endpoint to [get the status of the copy operation](onenoteoperation-get.md).
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/section-copytosectiongroup.md
+++ b/api-reference/beta/api/section-copytosectiongroup.md
@@ -60,7 +60,7 @@ In the request body, provide a JSON object that contains the parameters that you
 If successful, this method returns a `202 Accepted` response code and an `Operation-Location` header. Poll the Operation-Location endpoint to [get the status of the copy operation](onenoteoperation-get.md).
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/security-emailthreatsubmission-get.md
+++ b/api-reference/beta/api/security-emailthreatsubmission-get.md
@@ -51,7 +51,7 @@ If successful, this method returns a `200 OK` response code and an [emailThreatS
 ## Examples
 
 ### Request
-Here's an example  of a request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -94,7 +94,7 @@ GET https://graph.microsoft.com/beta/security/threatSubmission/emailThreats/{ema
 ---
 
 ### Response
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 <!-- {

--- a/api-reference/beta/api/security-emailthreatsubmissionpolicy-get.md
+++ b/api-reference/beta/api/security-emailthreatsubmissionpolicy-get.md
@@ -51,7 +51,7 @@ If successful, this method returns a `200 OK` response code and an [emailThreatS
 ## Examples
 
 ### Request
-Here's an example  of a request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -94,7 +94,7 @@ GET https://graph.microsoft.com/beta/security/threatSubmission/emailThreatSubmis
 ---
 
 ### Response
-Here's an example  of the response.
+The following example shows the response.
 
 > **Note:** The response object shown here might be shortened for readability.
 

--- a/api-reference/beta/api/serviceprincipal-delete-delegatedpermissionclassifications.md
+++ b/api-reference/beta/api/serviceprincipal-delete-delegatedpermissionclassifications.md
@@ -53,7 +53,7 @@ If successful, this method returns a `204 No Content` response code. It doesn't 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 
 # [HTTP](#tab/http)
@@ -98,7 +98,7 @@ DELETE https://graph.microsoft.com/beta/servicePrincipals/{id}/delegatedPermissi
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/servicestoragequotabreakdown-get.md
+++ b/api-reference/beta/api/servicestoragequotabreakdown-get.md
@@ -52,7 +52,7 @@ If successful, this method returns a `200 OK` response code and a [serviceStorag
 ## Examples
 
 ### Request
-Here's an example  of a request.
+The following example shows a request.
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -94,7 +94,7 @@ GET https://graph.microsoft.com/beta/me/settings/storage/quota/services/OneDrive
 ---
 
 ### Response
-Here's an example  of the response
+The following example shows the response
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/synchronization-synchronization-list-templates.md
+++ b/api-reference/beta/api/synchronization-synchronization-list-templates.md
@@ -50,7 +50,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ### Example
 
 ##### Request
-Here's an example  of a request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -92,7 +92,7 @@ GET https://graph.microsoft.com/beta/servicePrincipals/{id}/synchronization/temp
 ---
 
 ##### Response
-Here's an example  of a response.
+The following example shows a response.
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/synchronization-synchronizationjob-pause.md
+++ b/api-reference/beta/api/synchronization-synchronizationjob-pause.md
@@ -49,7 +49,7 @@ If successful, returns a `204 No Content` response. It doesn't return anything i
 ## Example
 
 ### Request
-Here's an example  of a request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -91,7 +91,7 @@ POST https://graph.microsoft.com/beta/servicePrincipals/{id}/synchronization/job
 ---
 
 ### Response
-Here's an example  of a response.
+The following example shows the response.
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/beta/api/table-clearfilters.md
+++ b/api-reference/beta/api/table-clearfilters.md
@@ -46,7 +46,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/table-converttorange.md
+++ b/api-reference/beta/api/table-converttorange.md
@@ -46,7 +46,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/table-databodyrange.md
+++ b/api-reference/beta/api/table-databodyrange.md
@@ -46,7 +46,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}/
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/table-delete.md
+++ b/api-reference/beta/api/table-delete.md
@@ -46,7 +46,7 @@ DELETE /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|nam
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/table-headerrowrange.md
+++ b/api-reference/beta/api/table-headerrowrange.md
@@ -46,7 +46,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}/
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/table-post-rows.md
+++ b/api-reference/beta/api/table-post-rows.md
@@ -144,7 +144,7 @@ For async features, the user usually needs to issue 2-3 requests. This request, 
 
 #### Request
 
-Here's an example of the async request. Note that `202 Accepted` will only happen when the request takes a long time to respond. If the request is completed quickly, it works like a regular sync request, falling back to [Example 1](#example-1-add-two-rows-to-a-table).
+The following example shows the async request. Note that `202 Accepted` only happens when the request takes a long time to respond. If the request is completed quickly, it works like a regular sync request, falling back to [Example 1](#example-1-add-two-rows-to-a-table).
 
 
 

--- a/api-reference/beta/api/table-reapplyfilters.md
+++ b/api-reference/beta/api/table-reapplyfilters.md
@@ -46,7 +46,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/table-totalrowrange.md
+++ b/api-reference/beta/api/table-totalrowrange.md
@@ -46,7 +46,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}/
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablecollection-add.md
+++ b/api-reference/beta/api/tablecollection-add.md
@@ -56,7 +56,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookTable](../resources/workbooktable.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablecolumn-databodyrange.md
+++ b/api-reference/beta/api/tablecolumn-databodyrange.md
@@ -46,7 +46,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}/
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablecolumn-delete.md
+++ b/api-reference/beta/api/tablecolumn-delete.md
@@ -46,7 +46,7 @@ DELETE /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|nam
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablecolumn-headerrowrange.md
+++ b/api-reference/beta/api/tablecolumn-headerrowrange.md
@@ -46,7 +46,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}/
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablecolumn-range.md
+++ b/api-reference/beta/api/tablecolumn-range.md
@@ -46,7 +46,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}/
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md)) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablecolumn-totalrowrange.md
+++ b/api-reference/beta/api/tablecolumn-totalrowrange.md
@@ -46,7 +46,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}/
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablecolumncollection-add.md
+++ b/api-reference/beta/api/tablecolumncollection-add.md
@@ -52,7 +52,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookTableColumn](../resources/workbooktablecolumn.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablecolumncollection-itemat.md
+++ b/api-reference/beta/api/tablecolumncollection-itemat.md
@@ -56,7 +56,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookTableColumn](../resources/workbooktablecolumn.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablerow-delete.md
+++ b/api-reference/beta/api/tablerow-delete.md
@@ -46,7 +46,7 @@ DELETE /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|nam
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablerow-range.md
+++ b/api-reference/beta/api/tablerow-range.md
@@ -53,7 +53,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablerowcollection-itemat.md
+++ b/api-reference/beta/api/tablerowcollection-itemat.md
@@ -56,7 +56,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookTableRow](../resources/workbooktablerow.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablesort-apply.md
+++ b/api-reference/beta/api/tablesort-apply.md
@@ -53,7 +53,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablesort-clear.md
+++ b/api-reference/beta/api/tablesort-clear.md
@@ -46,7 +46,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/tablesort-reapply.md
+++ b/api-reference/beta/api/tablesort-reapply.md
@@ -46,7 +46,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}/tables/{id|name}
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/team-completemigration.md
+++ b/api-reference/beta/api/team-completemigration.md
@@ -51,7 +51,7 @@ If successful, this method returns a `204 No Content` response code. It doesn't 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 <!-- markdownlint-disable MD025 -->
 <!-- markdownlint-disable MD022 -->
 
@@ -101,7 +101,7 @@ POST https://graph.microsoft.com/beta/teams/57fb72d0-d811-46f4-8947-305e6072eaa5
 <!-- markdownlint-disable MD024 -->
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/beta/api/team-post.md
+++ b/api-reference/beta/api/team-post.md
@@ -836,7 +836,7 @@ The following are common reasons for this response:
 
 ### Example 10: Application permissions using user principal name
 
-Here's an example of a minimal request using application permissions. Because the client omitted other properties, it's implicitly taking defaults from the predefined template represented by `template`. You must specify a [user](../resources/user.md) in the `members` collection for requests with application permissions.
+The following example shows a minimal request using application permissions. Because the client omitted other properties, it's implicitly taking defaults from the predefined template represented by `template`. You must specify a [user](../resources/user.md) in the `members` collection for requests with application permissions.
 
 #### Request
 

--- a/api-reference/beta/api/tiindicators-list.md
+++ b/api-reference/beta/api/tiindicators-list.md
@@ -104,7 +104,7 @@ GET https://graph.microsoft.com/beta/security/tiIndicators
 
 The following example shows the response.
 
-> >**Note:** The response object shown here might be shortened for readability.
+>**Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/tiindicators-list.md
+++ b/api-reference/beta/api/tiindicators-list.md
@@ -58,7 +58,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-Here's an example  of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -102,10 +102,9 @@ GET https://graph.microsoft.com/beta/security/tiIndicators
 
 ### Response
 
-Here's an example  of the response.
+The following example shows the response.
 
-> [!NOTE]
-> The response object shown here might be shortened for readability.
+> >**Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/unifiedstoragequota-list-services.md
+++ b/api-reference/beta/api/unifiedstoragequota-list-services.md
@@ -52,7 +52,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 ## Examples
 
 ### Request
-Here's an example  of a request.
+The following example shows a request.
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
@@ -94,7 +94,7 @@ GET https://graph.microsoft.com/beta/me/settings/storage/quota/services
 ---
 
 ### Response
-Here's an example  of the response
+The following example shows the response
 >**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/user-delta.md
+++ b/api-reference/beta/api/user-delta.md
@@ -152,7 +152,7 @@ GET https://graph.microsoft.com/beta/users/delta
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization.
 
 >**Note:** The response object shown here might be shortened for readability.
 
@@ -238,7 +238,7 @@ GET https://graph.microsoft.com/beta/users/delta?$select=displayName,jobTitle,mo
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization. All three properties are included in the response and it isn't known which ones have changed since the `@odata.deltaLink` was obtained.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization. All three properties are included in the response and it isn't known which ones have changed since the `@odata.deltaLink` was obtained.
 
 <!-- {
   "blockType": "response",
@@ -313,7 +313,7 @@ Prefer: return=minimal
 
 #### Response
 
-Here's an example of the response when using `@odata.deltaLink` obtained from the query initialization. The `mobilePhone` property isn't included, which means it hasn't changed since the last delta query; `displayName` and `jobTitle` are included which means their values have changed.
+The following example shows the response when using `@odata.deltaLink` obtained from the query initialization. The `mobilePhone` property isn't included, which means it hasn't changed since the last delta query; `displayName` and `jobTitle` are included which means their values have changed.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/user-findmeetingtimes.md
+++ b/api-reference/beta/api/user-findmeetingtimes.md
@@ -211,7 +211,7 @@ Content-Type: application/json
 ---
 
 ### Response
-Here is an example response. Note: The response object shown here might be shortened for readability.
+The following example shows the response. Note: The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/beta/api/user-post-notifications.md
+++ b/api-reference/beta/api/user-post-notifications.md
@@ -96,7 +96,7 @@ Content-type: application/json
 ```
 
 ### Response
-Here's an example of the corresponding response.
+The following example shows the corresponding response.
 
 ```http
 HTTP/1.1 201

--- a/api-reference/beta/api/user-reminderview.md
+++ b/api-reference/beta/api/user-reminderview.md
@@ -53,7 +53,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [reminder](../resources/reminder.md) collection object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/usersettings-update.md
+++ b/api-reference/beta/api/usersettings-update.md
@@ -71,7 +71,7 @@ In the request body, supply the values for relevant fields that should be update
 
 ### Request
 
-Here's an example request on how to opt out a user from Delve and disable the user's contribution on content relevancy for the whole organization.
+The following example shows how to opt out a user from Delve and disable the user's contribution on content relevancy for the whole organization.
 
 ```http
 PATCH https://graph.microsoft.com/beta/me/settings

--- a/api-reference/beta/api/workbookpivottable-refresh.md
+++ b/api-reference/beta/api/workbookpivottable-refresh.md
@@ -45,7 +45,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id}/pivotTables/{id}/refr
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/workbookpivottable-refreshall.md
+++ b/api-reference/beta/api/workbookpivottable-refreshall.md
@@ -44,7 +44,7 @@ POST /me/drive/root:/{item-path}:/workbook/worksheets/{id}/pivotTables/refreshAl
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/workbookrange-columnsafter.md
+++ b/api-reference/beta/api/workbookrange-columnsafter.md
@@ -51,7 +51,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/workbookrange-columnsbefore.md
+++ b/api-reference/beta/api/workbookrange-columnsbefore.md
@@ -51,7 +51,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/workbookrange-rowsabove.md
+++ b/api-reference/beta/api/workbookrange-rowsabove.md
@@ -52,7 +52,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/workbookrange-rowsbelow.md
+++ b/api-reference/beta/api/workbookrange-rowsbelow.md
@@ -52,7 +52,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/workbookrange-visibleview.md
+++ b/api-reference/beta/api/workbookrange-visibleview.md
@@ -41,7 +41,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id}/range(address={address
 If successful, this method returns `200 OK` response code and [workbookRangeView](../resources/workbookrangeview.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/workbookrangeview-itemat.md
+++ b/api-reference/beta/api/workbookrangeview-itemat.md
@@ -50,7 +50,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRangeView](../resources/workbookrangeview.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 <!-- {

--- a/api-reference/beta/api/workbookrangeview-range.md
+++ b/api-reference/beta/api/workbookrangeview-range.md
@@ -43,7 +43,7 @@ GET /me/drive/root:/{item-path}:/workbook/worksheets/{id}/range(address={address
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/workforceintegration-update.md
+++ b/api-reference/beta/api/workforceintegration-update.md
@@ -221,7 +221,8 @@ Accept-Language: en-us
 ```
 #### Response
 
-Here's an example of the response from the workforce integration service.
+The following example shows the response from the workforce integration service.
+
 ```
 HTTP/1.1 200 OK
 {

--- a/api-reference/beta/api/worksheet-cell.md
+++ b/api-reference/beta/api/worksheet-cell.md
@@ -54,7 +54,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 # [HTTP](#tab/http)

--- a/api-reference/beta/api/worksheet-delete.md
+++ b/api-reference/beta/api/worksheet-delete.md
@@ -44,7 +44,7 @@ DELETE /me/drive/root:/{item-path}:/workbook/worksheets/{id|name}
 If successful, this method returns `204 No Content` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/worksheet-range.md
+++ b/api-reference/beta/api/worksheet-range.md
@@ -49,7 +49,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/worksheet-usedrange.md
+++ b/api-reference/beta/api/worksheet-usedrange.md
@@ -51,7 +51,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-The following example shows that shows how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/worksheet-usedrange.md
+++ b/api-reference/beta/api/worksheet-usedrange.md
@@ -51,7 +51,7 @@ Don't supply a request body for this method.
 If successful, this method returns `200 OK` response code and [workbookRange](../resources/workbookrange.md) object in the response body.
 
 ## Example
-Here's an example that shows how to call this API.
+The following example shows that shows how to call this API.
 ### Request
 The following example shows a request.
 

--- a/api-reference/beta/api/worksheetprotection-protect.md
+++ b/api-reference/beta/api/worksheetprotection-protect.md
@@ -49,7 +49,7 @@ In the request body, provide a JSON object with the following parameters.
 If successful, this method returns `200 OK` response code. It doesn't return anything in the response body.
 
 ## Example
-Here is an example of how to call this API.
+The following example shows how to call this API.
 ### Request
 The following example shows a request.
 


### PR DESCRIPTION
This PR’s main objective is to standardize example-introduction wording across the beta API documentation by replacing variations like “Here’s an example” with “The following example,” so the docs read more consistently, use a more formal tone, and provide a uniform experience for readers without changing any API behavior or technical content.