### PR TITLE
AB#586974: Clarify roles for reading application and service principal objects

### DIFF
--- a/api-reference/beta/includes/rbac-for-apis/rbac-application-apis-read.md
+++ b/api-reference/beta/includes/rbac-for-apis/rbac-application-apis-read.md
@@ -1,11 +1,12 @@
 ---
 author: Jackson-Woods
 ms.topic: include
+ai-usage: ai-assisted
+ms.custom: msecd-doc-authoring-1023
 ---
 
 > [!IMPORTANT]
-> For delegated access using work or school accounts where the signed-in user is acting on another user, they must be assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. This operation supports the following built-in roles, which provide only the least privilege necessary:
-> - A non-admin member or guest user with default user permissions
+> For delegated access using work or school accounts, a non-admin member or guest user can perform this operation with default user permissions. A signed-in user can also perform this operation if they're assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. The following built-in roles are supported:
 > - Application Developer - read properties of application they own
 > - Directory Readers - read standard properties
 > - Global Secure Access Administrator - read standard properties

--- a/api-reference/beta/includes/rbac-for-apis/rbac-serviceprincipal-apis-read.md
+++ b/api-reference/beta/includes/rbac-for-apis/rbac-serviceprincipal-apis-read.md
@@ -1,11 +1,12 @@
 ---
 author: Jackson-Woods
 ms.topic: include
+ai-usage: ai-assisted
+ms.custom: msecd-doc-authoring-1023
 ---
 
 > [!IMPORTANT]
-> For delegated access using work or school accounts where the signed-in user is acting on another user, they must be assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. This operation supports the following built-in roles, which provide only the least privilege necessary:
-> - A non-admin member or guest user with default user permissions
+> For delegated access using work or school accounts, a non-admin member or guest user can perform this operation with default user permissions. A signed-in user can also perform this operation if they're assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. The following built-in roles are supported:
 > - Application Developer - read properties of service principals they own
 > - Directory Readers - read standard properties
 > - Global Reader

--- a/api-reference/v1.0/includes/rbac-for-apis/rbac-application-apis-read.md
+++ b/api-reference/v1.0/includes/rbac-for-apis/rbac-application-apis-read.md
@@ -1,11 +1,12 @@
 ---
 author: Jackson-Woods
 ms.topic: include
+ai-usage: ai-assisted
+ms.custom: msecd-doc-authoring-1023
 ---
 
 > [!IMPORTANT]
-> For delegated access using work or school accounts where the signed-in user is acting on another user, they must be assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. This operation supports the following built-in roles, which provide only the least privilege necessary:
-> - A non-admin member or guest user with default user permissions
+> For delegated access using work or school accounts, a non-admin member or guest user can perform this operation with default user permissions. A signed-in user can also perform this operation if they're assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. The following built-in roles are supported:
 > - Application Developer - read properties of application they own
 > - Directory Readers - read standard properties
 > - Global Secure Access Administrator - read standard properties

--- a/api-reference/v1.0/includes/rbac-for-apis/rbac-serviceprincipal-apis-read.md
+++ b/api-reference/v1.0/includes/rbac-for-apis/rbac-serviceprincipal-apis-read.md
@@ -1,11 +1,12 @@
 ---
 author: Jackson-Woods
 ms.topic: include
+ai-usage: ai-assisted
+ms.custom: msecd-doc-authoring-1023
 ---
 
 > [!IMPORTANT]
-> For delegated access using work or school accounts where the signed-in user is acting on another user, they must be assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. This operation supports the following built-in roles, which provide only the least privilege necessary:
-> - A non-admin member or guest user with default user permissions
+> For delegated access using work or school accounts, a non-admin member or guest user can perform this operation with default user permissions. A signed-in user can also perform this operation if they're assigned a supported [Microsoft Entra role](/entra/identity/role-based-access-control/permissions-reference?toc=%2Fgraph%2Ftoc.json) or a custom role that grants the permissions required for this operation. The following built-in roles are supported:
 > - Application Developer - read properties of service principals they own
 > - Directory Readers - read standard properties
 > - Global Reader


### PR DESCRIPTION
## Summary

Clarifies delegated permission guidance for reading application and service principal objects. Non-admin members and guests can perform these operations with default user permissions and don't require an assigned Microsoft Entra role.

## Implements

- [AB#586974](https://dev.azure.com/msft-skilling/Content/_workitems/edit/586974) - Application API docs state admin roles are required to read SP objects when default user is sufficient

## How to validate

- Confirm the application and service principal read RBAC includes state that non-admin members and guests can use default user permissions.
- Confirm supported Microsoft Entra roles remain listed as additional options.
- Confirm the guidance is consistent across beta and v1.0.
