### PR TITLE
Add RoleManagement.Read/ReadWrite.EntitlementManagement permissions to entitlement management RBAC provider

### DIFF
--- a/api-reference/beta/api/rbacapplication-list-roleassignments.md
+++ b/api-reference/beta/api/rbacapplication-list-roleassignments.md
@@ -45,7 +45,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All   |
+|Delegated (work or school account) |  RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All   |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Not supported. |
 

--- a/api-reference/beta/api/rbacapplication-list-roledefinitions.md
+++ b/api-reference/beta/api/rbacapplication-list-roledefinitions.md
@@ -71,7 +71,7 @@ Depending on the RBAC provider and the permission type (delegated or application
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All   |
+|Delegated (work or school account) |  RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All   |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Not supported. |
 

--- a/api-reference/beta/api/rbacapplication-post-roleassignments.md
+++ b/api-reference/beta/api/rbacapplication-post-roleassignments.md
@@ -39,7 +39,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.ReadWrite.All   |
+|Delegated (work or school account) |  RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All   |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Not supported. |
 

--- a/api-reference/beta/api/unifiedroleassignment-delete.md
+++ b/api-reference/beta/api/unifiedroleassignment-delete.md
@@ -39,7 +39,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.ReadWrite.All  |
+|Delegated (work or school account) |  RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All  |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Not supported. |
 

--- a/api-reference/beta/api/unifiedroleassignment-get.md
+++ b/api-reference/beta/api/unifiedroleassignment-get.md
@@ -40,7 +40,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All  |
+|Delegated (work or school account) |  RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All  |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Not supported. |
 

--- a/api-reference/beta/api/unifiedroledefinition-get.md
+++ b/api-reference/beta/api/unifiedroledefinition-get.md
@@ -71,9 +71,9 @@ Depending on the RBAC provider and the permission type (delegated or application
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All   |
+|Delegated (work or school account) |  RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All   |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All |
+|Application | RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All |
 
 ### For an Exchange Online provider
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->

--- a/api-reference/v1.0/api/rbacapplication-list-roleassignments.md
+++ b/api-reference/v1.0/api/rbacapplication-list-roleassignments.md
@@ -42,9 +42,9 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All   |
+|Delegated (work or school account) |  RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All   |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All  |
+|Application | RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All  |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/rbacapplication-list-roledefinitions.md
+++ b/api-reference/v1.0/api/rbacapplication-list-roledefinitions.md
@@ -41,9 +41,9 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All   |
+|Delegated (work or school account) |  RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All   |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All |
+|Application | RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/rbacapplication-post-roleassignments.md
+++ b/api-reference/v1.0/api/rbacapplication-post-roleassignments.md
@@ -37,9 +37,9 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.ReadWrite.All   |
+|Delegated (work or school account) |  RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All   |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | EntitlementManagement.ReadWrite.All |
+|Application | RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/unifiedroleassignment-delete.md
+++ b/api-reference/v1.0/api/unifiedroleassignment-delete.md
@@ -37,9 +37,9 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.ReadWrite.All  |
+|Delegated (work or school account) |  RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All  |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | EntitlementManagement.ReadWrite.All |
+|Application | RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/unifiedroleassignment-get.md
+++ b/api-reference/v1.0/api/unifiedroleassignment-get.md
@@ -38,9 +38,9 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All  |
+|Delegated (work or school account) |  RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All  |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All |
+|Application | RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/unifiedroledefinition-get.md
+++ b/api-reference/v1.0/api/unifiedroledefinition-get.md
@@ -42,9 +42,9 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored"  } // Note: Removing this line will result in the permissions autogeneration tool overwriting the table. -->
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All   |
+|Delegated (work or school account) |  RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All   |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All  |
+|Application | RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All  |
 
 ## HTTP request
 


### PR DESCRIPTION
## Summary

This PR adds two new provider-scoped least-privilege permissions to the **entitlement management** Microsoft Graph Unified RBAC provider (`/roleManagement/entitlementManagement/...`) documentation:

- **`RoleManagement.Read.EntitlementManagement`** – read-only access to entitlement management RBAC role definitions and role assignments (GET on all four EM RBAC paths).
- **`RoleManagement.ReadWrite.EntitlementManagement`** – read + write access, including `POST /roleAssignments` and `DELETE /roleAssignments/{id}`.

Both require admin consent, support Delegated (work or school) and Application permission types, and do **not** support personal Microsoft accounts.

Today the entitlement management provider only documents the very broad `EntitlementManagement.Read.All` / `EntitlementManagement.ReadWrite.All`. This aligns the EM provider with the CloudPC, Exchange, and Defender providers, which already expose dedicated `RoleManagement.Read.<Provider>` / `RoleManagement.ReadWrite.<Provider>` pairs.

## This change is purely additive

No existing permission is removed. `EntitlementManagement.Read.All` / `EntitlementManagement.ReadWrite.All` are retained in every table. The new provider-scoped permission is listed **first** because these tables are ordered from least to most privileged:

- Read/list ops: `RoleManagement.Read.EntitlementManagement, EntitlementManagement.Read.All, RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All`
- Write ops (POST/DELETE roleAssignments): `RoleManagement.ReadWrite.EntitlementManagement, EntitlementManagement.ReadWrite.All`

Only the entitlement management provider tables were touched. The directory / CloudPC / Intune / Defender / Exchange Online provider tables, the `blockType: ignored` guard comments, and all `[!INCLUDE ...]` auto-generated permission blocks are unchanged.

## Paired service PRs

This documentation PR is intended to ship together with the Microsoft-internal service PRs that declare and implement the two new permissions:

- **Permission reference (AD-AggregatorService-Workloads):** https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/16823513
- **Service implementation (AD-IGA-Store):** https://msazure.visualstudio.com/One/_git/AD-IGA-Store/pullrequest/16823514

> ⚠️ **Do not merge this docs PR until the two service PRs have shipped, in this exact order.** The rollout must be sequenced as follows:
>
> 1. **ELM service PR [16823514](https://msazure.visualstudio.com/One/_git/AD-IGA-Store/pullrequest/16823514) (AD-IGA-Store) merges and deploys to all rings FIRST.** It is inert until the permission exists, because no token can carry a scope that isn't declared in the Graph permission store.
> 2. **AGS permission reference PR [16823513](https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/16823513) merges SECOND.** Its `provisioningInfo` entries are `isEnabled: true` (hidden from the consent UI but grantable by ID), so the moment it ships the scopes become mintable — and if ELM hadn't already deployed, callers would get a `401`.
> 3. **This docs PR merges LAST,** once the permission is actually usable end to end.
>
> In short: **ELM deploys first, then AGS, then these docs.** This PR must not merge until the AGS permission reference PR ([16823513](https://msazure.visualstudio.com/One/_git/AD-AggregatorService-Workloads/pullrequest/16823513)) has shipped (which itself must follow the ELM deployment), because the `RoleManagement.Read.EntitlementManagement` / `RoleManagement.ReadWrite.EntitlementManagement` permissions are not usable by customers until then. Kept as a **draft** until then.

## Files changed (12)

Entitlement management provider permission tables updated in both v1.0 and beta:

| File | Rows updated |
|------|--------------|
| `api-reference/v1.0/api/rbacapplication-list-roleassignments.md` | Delegated + Application (read) |
| `api-reference/v1.0/api/rbacapplication-list-roledefinitions.md` | Delegated + Application (read) |
| `api-reference/v1.0/api/unifiedroleassignment-get.md` | Delegated + Application (read) |
| `api-reference/v1.0/api/unifiedroledefinition-get.md` | Delegated + Application (read) |
| `api-reference/v1.0/api/rbacapplication-post-roleassignments.md` | Delegated + Application (write only) |
| `api-reference/v1.0/api/unifiedroleassignment-delete.md` | Delegated + Application (write only) |
| `api-reference/beta/api/rbacapplication-list-roleassignments.md` | Delegated (read) — Application left `Not supported.` |
| `api-reference/beta/api/rbacapplication-list-roledefinitions.md` | Delegated (read) — Application left `Not supported.` |
| `api-reference/beta/api/unifiedroleassignment-get.md` | Delegated (read) — Application left `Not supported.` |
| `api-reference/beta/api/unifiedroledefinition-get.md` | Delegated + Application (read) |
| `api-reference/beta/api/rbacapplication-post-roleassignments.md` | Delegated (write only) — Application left `Not supported.` |
| `api-reference/beta/api/unifiedroleassignment-delete.md` | Delegated (write only) — Application left `Not supported.` |

`concepts/permissions-reference.md` is intentionally **not** edited — its per-permission `### <PermissionName>` sections are generated from the service permission declarations and will pick up the new permissions automatically once the service change ships.

## Known v1.0-vs-beta discrepancy (not fixed here)

For the entitlement management provider, several **beta** pages list **Application = `Not supported.`** while the corresponding **v1.0** pages list Application as supported (e.g., `rbacapplication-list-roleassignments.md`). This pre-existing inconsistency was intentionally left as-is (Application rows that say `Not supported.` in beta were not changed) so it can be investigated/corrected separately by the author.
