### PR TITLE
Add note to create userSource page regarding sites.read.all permission requirement

### DIFF
--- a/api-reference/v1.0/api/security-ediscoverycustodian-post-usersources.md
+++ b/api-reference/v1.0/api/security-ediscoverycustodian-post-usersources.md
@@ -25,6 +25,7 @@ Choose the permission or permissions marked as least privileged for this API. Us
 
 [!INCLUDE [rbac-ediscovery-custodian](../includes/rbac-for-apis/rbac-ediscovery-custodian-export-apis.md)]
 
+[!INCLUDE [rbac-ediscovery-apis-sitesread](../includes/rbac-for-apis/rbac-ediscovery-apis-sitesread.md)]
 ## HTTP request
 
 <!-- {

--- a/api-reference/v1.0/includes/rbac-for-apis/rbac-ediscovery-apis-sitesread.md
+++ b/api-reference/v1.0/includes/rbac-for-apis/rbac-ediscovery-apis-sitesread.md
@@ -1,0 +1,7 @@
+---
+author: avbaker
+ms.topic: include
+---
+
+> [!NOTE]
+> The Sites.Read.All permission is required for site resolution to create site userSource objects.


### PR DESCRIPTION
> [!IMPORTANT]
> Use the AI-powered workflow for Graph onboarding to author and self-review schema-related changes. See https://aka.ms/msgraphcdk for more information.
> 
> Required for API changes:
> - [] Link to API.md file: api-reference/v1.0/api/security-ediscoverycustodian-post-usersources.md 
> - [] Link to **PR** for public-facing schema changes (schema-Prod-beta/v1.0.csdl):  *ADD LINK HERE*

---
Add other supporting information, such as a description of the PR changes:

Creates api-reference/v1.0/includes/rbac-for-apis/rbac-ediscovery-apis-sitesread.md and includes it in to add note about Sites.Read.All permissions being required for site resolution create using create userSource method to add sites to the userSource.

---
> [!IMPORTANT]
> The following guidance is for Microsoft employees only. Community contributors can ignore this message; our content team will manage the status.
<details><summary><i>After you've created your PR</i>, expand this section for tips and additional instructions.</summary>


- **do not merge** is the default PR status and is automatically added to all open PRs that don't have the **ready to merge** label.
- Add the **ready for content review** label to start a review. Only PRs that have met the [minimum requirements for content review](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/679c4bf497d767aa4c1e409cd143d7109564b93a118c29e0e11b15eb04b78844) and have this label are reviewed.
- If your content reviewer requests changes, review the feedback and address accordingly as soon as possible to keep your pull request moving forward. After you address the feedback, remove the **changes requested** label, add the **review feedback addressed** label, and select the **Re-request review** icon next to the content reviewer's alias. If you can't add labels, add a comment with `#feedback-addressed` to the pull request.
- After the content review is complete, your reviewer will add the **content review complete** label. When the updates in this PR are ready for external customers to use, replace the **do not merge** label with **ready to merge** and the PR will be merged within 24 working hours.
- Pull requests that are inactive for more than 6 weeks will be automatically closed. Before that, you receive reminders at 2 weeks, 4 weeks, and 6 weeks. If you still need the PR, you can reopen or recreate the request.

For more information, see the [Content review process summary](https://eng.ms/cid/27dee76c-3a60-4e65-8fdf-08ea849b3498/fid/3a993b6c9d547e46f59d8d7851f191c38bbbea6ead01253dc62fcdd8101a1ff9).

</details>
